### PR TITLE
feat(bot): add per-guild command prefix support

### DIFF
--- a/app/cogs/aiprompts/aiprompts.py
+++ b/app/cogs/aiprompts/aiprompts.py
@@ -160,9 +160,10 @@ class OpenAIPrompts(
         if isinstance(message.channel, discord.DMChannel):
             return
 
-        if message.content.startswith(self.bot.command_prefix):
+        prefix = self.bot.get_guild_prefix(message.guild)
+        if message.content.startswith(prefix):
             command_name, *args = message.content.split(" ")
-            command_name = command_name[len(self.bot.command_prefix) :]
+            command_name = command_name[len(prefix) :]
 
             prompt_config = AIPromptConfig.get_or_none(
                 guild_id=message.guild.id, name=command_name.lower()

--- a/app/cogs/bot/bot.py
+++ b/app/cogs/bot/bot.py
@@ -2,6 +2,7 @@ import discord
 from cogs.lancocog import LancoCog
 from discord import app_commands
 from utils.command_utils import is_bot_owner, is_bot_owner_or_admin
+from utils.config import GuildConfig
 
 
 class Bot(LancoCog, name="Bot", description="Bot configuration commands"):
@@ -60,6 +61,47 @@ class Bot(LancoCog, name="Bot", description="Bot configuration commands"):
     async def setname(self, interaction: discord.Interaction, name: str):
         await interaction.guild.me.edit(nick=name)
         await interaction.response.send_message(f"Name set to {name}", ephemeral=True)
+
+    @app_commands.command(
+        name="setprefix",
+        description="Set the command prefix for this guild",
+    )
+    @is_bot_owner_or_admin()
+    async def setprefix(self, interaction: discord.Interaction, prefix: str):
+        import main
+
+        if len(prefix) > 2:
+            await interaction.response.send_message(
+                "Prefix must be 2 characters or fewer.", ephemeral=True
+            )
+            return
+
+        guild_id = interaction.guild.id
+        config, _ = GuildConfig.get_or_create(guild_id=guild_id)
+        config.prefix = prefix
+        config.save()
+        main._prefix_cache[guild_id] = prefix
+        await interaction.response.send_message(
+            f"Prefix set to `{prefix}`", ephemeral=True
+        )
+
+    @app_commands.command(
+        name="prefix",
+        description="Show the current command prefix for this guild",
+    )
+    async def prefix(self, interaction: discord.Interaction):
+        import main
+
+        guild_id = interaction.guild.id
+        if guild_id in main._prefix_cache:
+            current = main._prefix_cache[guild_id]
+        else:
+            config = GuildConfig.get_or_none(guild_id=guild_id)
+            current = config.prefix if config and config.prefix else main.DEFAULT_PREFIX
+            main._prefix_cache[guild_id] = current
+        await interaction.response.send_message(
+            f"Current prefix: `{current}`", ephemeral=True
+        )
 
 
 async def setup(bot):

--- a/app/cogs/chatbot/chatbot.py
+++ b/app/cogs/chatbot/chatbot.py
@@ -73,7 +73,7 @@ class ChatBot(
         if message.author.bot:
             return
 
-        if message.content.startswith(self.bot.command_prefix):
+        if message.content.startswith(self.bot.get_guild_prefix(message.guild)):
             return
 
         is_reply = False

--- a/app/cogs/chatrelay/chatrelay.py
+++ b/app/cogs/chatrelay/chatrelay.py
@@ -33,7 +33,7 @@ class ChatRelay(
         if not self.recepient_channel_id:
             return
 
-        if message.content.startswith(self.bot.command_prefix):
+        if message.content.startswith(self.bot.get_guild_prefix(message.guild)):
             return
 
         self.logger.info(

--- a/app/cogs/commands/commands.py
+++ b/app/cogs/commands/commands.py
@@ -251,7 +251,7 @@ class Commands(LancoCog, name="Commands", description="Custom guild commands"):
         commands = list(commands)
         commands.sort(key=lambda x: x.command_name)
 
-        prefix = self.bot.command_prefix
+        prefix = self.bot.get_guild_prefix(interaction.guild)
 
         for i in range(0, len(commands), COMMANDS_PER_PAGE):
             page_commands = commands[i : i + COMMANDS_PER_PAGE]
@@ -298,8 +298,9 @@ class Commands(LancoCog, name="Commands", description="Custom guild commands"):
         if isinstance(message.channel, discord.DMChannel):
             return None
 
-        if message.content.startswith(self.bot.command_prefix):
-            command_name = message.content[len(self.bot.command_prefix) :]
+        prefix = self.bot.get_guild_prefix(message.guild)
+        if message.content.startswith(prefix):
+            command_name = message.content[len(prefix) :]
             command = CustomCommands.get_or_none(
                 guild_id=message.guild.id, command_name=command_name.lower()
             )

--- a/app/cogs/onewordstory/onewordstory.py
+++ b/app/cogs/onewordstory/onewordstory.py
@@ -49,7 +49,7 @@ class OneWordStory(LancoCog, name="OneWordStory", description="One Word Story ga
 
         # ignore native commands
         if (
-            message.content.startswith(self.bot.command_prefix)
+            message.content.startswith(self.bot.get_guild_prefix(message.guild))
             and len(message.content) > 1
         ):
             return

--- a/app/cogs/tipcalc/tipcalc.py
+++ b/app/cogs/tipcalc/tipcalc.py
@@ -122,9 +122,7 @@ class TipCalc(LancoCog, name="TipCalc", description="Tip calculator commands"):
             response += "\n"
 
         if not valid_tip_perc:
-            example = (
-                f"Example: ```{self.bot.command_prefix}tip {bill_amount:.2f} 22```"
-            )
+            example = f"Example: ```{self.bot.get_guild_prefix(interaction.guild)}tip {bill_amount:.2f} 22```"
             if is_slash_command:
                 example = f"Example: ```/{ctx.command} {bill_amount:.2f} 22```"
             response += f"Tip: You can provide a custom tip percentage as the 2nd argument. {example}"

--- a/app/cogs/webpreview/webpreview.py
+++ b/app/cogs/webpreview/webpreview.py
@@ -29,7 +29,7 @@ class WebPreview(LancoCog, name="WebPreview", description="WebPreview cog"):
     async def on_message(self, message: discord.Message):
         if message.author.bot:
             return
-        if message.content.startswith(self.bot.command_prefix):
+        if message.content.startswith(self.bot.get_guild_prefix(message.guild)):
             return
         if not message.channel.permissions_for(message.guild.me).embed_links:
             return

--- a/app/main.py
+++ b/app/main.py
@@ -124,6 +124,17 @@ if os.getenv("LOGTAIL_TOKEN"):
 
 intents = discord.Intents.all()
 
+DEFAULT_PREFIX = "."
+_prefix_cache: dict[int, str] = {}
+
+
+def get_prefix(bot, message):
+    if message.guild:
+        guild_prefix = _prefix_cache.get(message.guild.id, DEFAULT_PREFIX)
+        # Always include the default prefix so core bot commands remain accessible
+        return list({DEFAULT_PREFIX, guild_prefix})
+    return DEFAULT_PREFIX
+
 
 def init_db() -> SqliteDatabase:
     """Initialize and connect the database, returning the database instance."""
@@ -188,6 +199,18 @@ class LancoBot(commands.Bot):
 
     def set_dev_mode(self, mode: bool):
         self.dev_mode = mode
+
+    def get_guild_prefix(self, guild: Optional[discord.Guild] = None) -> str:
+        if guild:
+            if guild.id in _prefix_cache:
+                return _prefix_cache[guild.id]
+            from utils.config import GuildConfig
+
+            config = GuildConfig.get_or_none(guild_id=guild.id)
+            prefix = config.prefix if config and config.prefix else DEFAULT_PREFIX
+            _prefix_cache[guild.id] = prefix
+            return prefix
+        return DEFAULT_PREFIX
 
     def get_lanco_cog(self, cog_name: str) -> LancoCog:
         """Returns a LancoCog instance by name."""
@@ -283,7 +306,7 @@ class LancoBot(commands.Bot):
 owner_id = int(os.getenv("OWNER_ID", 0))
 message_cache_size = int(os.getenv("MESSAGE_CACHE_SIZE", 1000))
 bot = LancoBot(
-    command_prefix=".",
+    command_prefix=get_prefix,
     intents=intents,
     owner_id=owner_id,
     max_messages=message_cache_size,
@@ -788,7 +811,13 @@ async def unblock(interaction: discord.Interaction, user: discord.User):
 
 
 async def main():
+    from utils.config import GuildConfig
     from utils.db_backup import DatabaseBackup
+
+    database.create_tables([GuildConfig])
+    for config in GuildConfig.select():
+        if config.prefix:
+            _prefix_cache[config.guild_id] = config.prefix
 
     db_backup = DatabaseBackup()
     await load_cogs(bot)

--- a/app/utils/config.py
+++ b/app/utils/config.py
@@ -1,0 +1,33 @@
+import pytz
+from db import BaseModel
+from peewee import *
+
+
+class GuildConfig(BaseModel):
+    guild_id = IntegerField()
+    prefix = CharField(default=".")
+    timezone = CharField(default="UTC")
+
+    class Meta:
+        table_name = "guild_configs"
+
+    # helper method to convert timezone to pytz timezone
+    def get_pytz_timezone(self):
+        return pytz.timezone(self.timezone)
+
+
+def get_guild_config(guild_id: int) -> GuildConfig:
+    return GuildConfig.get_or_none(guild_id=guild_id)
+
+
+class UserConfig(BaseModel):
+    user_id = IntegerField()
+    setting_name = CharField()
+    setting_value = CharField()
+    guild_id = IntegerField(null=True)
+
+    def is_global_setting(self) -> bool:
+        return self.guild_id is None
+
+    class Meta:
+        table_name = "user_configs"

--- a/migrations/011_guild_config_prefix.py
+++ b/migrations/011_guild_config_prefix.py
@@ -1,0 +1,25 @@
+import os
+
+from dotenv import load_dotenv
+from playhouse.migrate import *
+
+load_dotenv()
+
+db = SqliteDatabase(os.getenv("SQLITE_DB"))
+
+migrator = SqliteMigrator(db)
+
+table_name = "guild_configs"
+
+new_columns = {
+    "prefix": CharField(default="."),
+}
+
+
+def run():
+    existing_columns = db.get_columns(table_name)
+    for column_name, field in new_columns.items():
+        if column_name not in [col.name for col in existing_columns]:
+            migrate(migrator.add_column(table_name, column_name, field))
+        else:
+            print(f"Column '{column_name}' already exists. No changes made.")


### PR DESCRIPTION
# Description

Adds support for per-guild command prefixes. Guild administrators can now set a custom prefix (max 2 characters) using `/setprefix`, which is persisted in `GuildConfig` and cached in-memory for fast lookup on every message. The `/prefix` command displays the current prefix for the guild, falling back to the DB on a cache miss to handle guilds that weren't seeded at startup.

The default prefix (`.`) is always accepted alongside any custom prefix, ensuring core bot commands like `.sync` remain accessible regardless of what a guild has configured. All cogs that previously referenced `self.bot.command_prefix` directly have been updated to use the new `bot.get_guild_prefix(message.guild)` helper.

Fixes #28