### PR TITLE
Feature/core cog refactor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ LancoBot is a modular Discord bot (Python / discord.py) built around a **cog sys
 
 **`app/run.py`** — Poetry script entrypoints for `dev`, `prod`, and `test`. Handles `sys.path` setup so bare imports work correctly.
 
-**`app/cogs/lancocog.py`** — `LancoCog` base class that all cogs inherit. Provides a per-cog logger, a scoped data directory, and context menu helpers. Every cog also defines a `CogDefinition` with name/description metadata.
+**`app/cogs/lancocog.py`** — `LancoCog` base class that all cogs inherit. Provides a per-cog logger, a scoped data directory, and context menu helpers.
 
 **`app/db.py`** — Peewee `DatabaseProxy` that abstracts SQLite (default) vs MySQL. All Peewee models should inherit `BaseModel` defined here; it binds to this proxy so the same model code works with either backend.
 
@@ -53,11 +53,19 @@ LancoBot is a modular Discord bot (Python / discord.py) built around a **cog sys
 
 ### Cog Pattern
 
+Each cog is a Python package. The directory must contain an `__init__.py` that re-exports `setup()` — this is what `load_extension("cogs.<name>")` resolves.
+
 ```
 app/cogs/mycog/
+├── __init__.py   # re-exports setup() — required
 ├── mycog.py      # main cog — inherits LancoCog
 ├── models.py     # optional Peewee models (if DB state is needed)
-└── README.md     # optional per-cog docs
+└── README.md     # per-cog docs
+```
+
+`__init__.py`:
+```python
+from .mycog import setup
 ```
 
 Minimal cog:
@@ -70,6 +78,7 @@ class MyCog(LancoCog, name="MyCog", description="My description"):
         super().__init__(bot)
 
     async def cog_load(self):
+        await super().cog_load()
         self.bot.database.create_tables([MyModel])  # create tables here, not in __init__
 
 async def setup(bot):
@@ -84,7 +93,7 @@ Several cogs (Spotify, Twitter/X, Instagram, TikTok fixes) register themselves a
 
 ### Development Mode
 
-Running `poetry run dev` loads `.env.dev` and sets `DEV_MODE=true` automatically, enabling `watchfiles`-based hot-reload: any change to a file under `app/cogs/` automatically reloads the affected cog without restarting the process.
+Running `poetry run dev` loads `.env.dev` and sets `DEV_MODE=true` automatically, enabling `watchfiles`-based hot-reload. A background task started in `setup_hook` watches `app/cogs/` — any file change triggers a reload of the affected cog package, including all submodules (`models.py`, etc.).
 
 ### Environment
 

--- a/README.md
+++ b/README.md
@@ -4,34 +4,84 @@ General-purpose Discord bot with some tailored features for Lancaster County, PA
 
 ## 🎉 Features
 
-The bot is built around a modular cog system. Each cog is self-contained and can be enabled or disabled independently. The following cogs are available:
+The bot is built around a modular cog system. Each cog is self-contained and can be enabled or disabled independently.
 
-|  |  |  |
-|---|---|---|
-| [TipCalc](https://github.com/NateShoffner/lanco-discord-bot/tree/master/app/cogs/tipcalc)<br>Tip calculator | [Magic8Ball](https://github.com/NateShoffner/lanco-discord-bot/tree/master/app/cogs/magic8ball)<br>Magic 8 Ball | [Twitter/X Embed Fix](https://github.com/NateShoffner/lanco-discord-bot/tree/master/app/cogs/twitterembed)<br>Fix Twitter/X embeds |
-| [TruthSocial](https://github.com/NateShoffner/lanco-discord-bot/tree/master/app/cogs/TruthSocial)<br>TruthSocial embed support | [RedditEmbed](https://github.com/NateShoffner/lanco-discord-bot/tree/master/app/cogs/redditembed)<br>Reddit embed fix | [BarHopper](https://github.com/NateShoffner/lanco-discord-bot/tree/master/app/cogs/barhopper)<br>Bar hopper commands |
-| [OneWordStory](https://github.com/NateShoffner/lanco-discord-bot/tree/master/app/cogs/onewordstory)<br>One word story game | [RoleStats](https://github.com/NateShoffner/lanco-discord-bot/tree/master/app/cogs/rolestats)<br>Server role statistics | [PeeCheck](https://github.com/NateShoffner/lanco-discord-bot/tree/master/app/cogs/peecheck)<br>PeeCheck cog |
-| [AIDetection](https://github.com/NateShoffner/lanco-discord-bot/tree/master/app/cogs/AIDetection)<br>Detect AI-generated content | [Fishbowl](https://github.com/NateShoffner/lanco-discord-bot/tree/master/app/cogs/fishbowl)<br>Fishbowl cog | [Conversions](https://github.com/NateShoffner/lanco-discord-bot/tree/master/app/cogs/conversions)<br>Unit conversions |
-| [AutoResponse](https://github.com/NateShoffner/lanco-discord-bot/tree/master/app/cogs/autoresponse)<br>Keyword auto-responses | [ChatBot](https://github.com/NateShoffner/lanco-discord-bot/tree/master/app/cogs/chatbot)<br>User-specific chatbot with agent memory | [RedditFeed](https://github.com/NateShoffner/lanco-discord-bot/tree/master/app/cogs/redditfeed)<br>Reddit feed polling |
-| [NewsHeadlines](https://github.com/NateShoffner/lanco-discord-bot/tree/master/app/cogs/newsheadlines)<br>News headlines | [Everbridge](https://github.com/NateShoffner/lanco-discord-bot/tree/master/app/cogs/everbridge)<br>Everbridge alerts | [RandomNsfwReddit](https://github.com/NateShoffner/lanco-discord-bot/tree/master/app/cogs/randomnsfwreddit)<br>Random NSFW Reddit posts |
-| [Google](https://github.com/NateShoffner/lanco-discord-bot/tree/master/app/cogs/google)<br>Google search | [SleepCheck](https://github.com/NateShoffner/lanco-discord-bot/tree/master/app/cogs/sleepcheck)<br>Sleep check commands | [ReactTrack](https://github.com/NateShoffner/lanco-discord-bot/tree/master/app/cogs/reacttrack)<br>Track reactions |
-| [WolframAlpha](https://github.com/NateShoffner/lanco-discord-bot/tree/master/app/cogs/wolframalpha)<br>Wolfram Alpha queries | [GameStats](https://github.com/NateShoffner/lanco-discord-bot/tree/master/app/cogs/gamestats)<br>Server game stats | [Admin](https://github.com/NateShoffner/lanco-discord-bot/tree/master/app/cogs/admin)<br>Admin commands |
-| [Summarize](https://github.com/NateShoffner/lanco-discord-bot/tree/master/app/cogs/summarize)<br>Summarize messages | [Fun](https://github.com/NateShoffner/lanco-discord-bot/tree/master/app/cogs/fun)<br>Fun commands | [AnimeToday](https://github.com/NateShoffner/lanco-discord-bot/tree/master/app/cogs/animetoday)<br>Daily anime announcements |
-| [Pinboard](https://github.com/NateShoffner/lanco-discord-bot/tree/master/app/cogs/pinboard)<br>Pin messages | [Birthday](https://github.com/NateShoffner/lanco-discord-bot/tree/master/app/cogs/birthday)<br>Birthday announcements | [Youtube](https://github.com/NateShoffner/lanco-discord-bot/tree/master/app/cogs/youtube)<br>YouTube feed polling |
-| [GeoGuesser](https://github.com/NateShoffner/lanco-discord-bot/tree/master/app/cogs/geoguesser)<br>Lancaster-themed GeoGuesser | [InstaEmbed](https://github.com/NateShoffner/lanco-discord-bot/tree/master/app/cogs/instaembed)<br>Instagram embed fix | [Describe](https://github.com/NateShoffner/lanco-discord-bot/tree/master/app/cogs/describe)<br>Describe images via context menu |
-| [Database Backupper](https://github.com/NateShoffner/lanco-discord-bot/tree/master/app/cogs/databasebackupper)<br>Scheduled DB backups | [NutCheck](https://github.com/NateShoffner/lanco-discord-bot/tree/master/app/cogs/nutcheck)<br>NutCheck cog | [SpyDotKick](https://github.com/NateShoffner/lanco-discord-bot/tree/master/app/cogs/spydotpet)<br>Detect loser bots |
-| [HotDog](https://github.com/NateShoffner/lanco-discord-bot/tree/master/app/cogs/hotdog)<br>Profile glizzies | [MarkSafe](https://github.com/NateShoffner/lanco-discord-bot/tree/master/app/cogs/marksafe)<br>Mark yourself safe | [EmoteTools](https://github.com/NateShoffner/lanco-discord-bot/tree/master/app/cogs/emotetools)<br>Emote and sticker tools |
-| [Verification](https://github.com/NateShoffner/lanco-discord-bot/tree/master/app/cogs/verification)<br>Member verification | [WebPreview](https://github.com/NateShoffner/lanco-discord-bot/tree/master/app/cogs/webpreview)<br>Web link previews | [TraceMoe](https://github.com/NateShoffner/lanco-discord-bot/tree/master/app/cogs/tracemoe)<br>Identify anime from screenshots |
-| [FixIt](https://github.com/NateShoffner/lanco-discord-bot/tree/master/app/cogs/fixit)<br>FixIt issue tracking | [UserProfiles](https://github.com/NateShoffner/lanco-discord-bot/tree/master/app/cogs/profile)<br>Custom user profiles | [PDFPreview](https://github.com/NateShoffner/lanco-discord-bot/tree/master/app/cogs/pdfpreview)<br>PDF preview generation |
-| [FortuneCookie](https://github.com/NateShoffner/lanco-discord-bot/tree/master/app/cogs/fortunecookie)<br>Fortune cookies | [Spotify Embed Fix](https://github.com/NateShoffner/lanco-discord-bot/tree/master/app/cogs/spotifyembed)<br>Fix Spotify embeds | [AutoReact](https://github.com/NateShoffner/lanco-discord-bot/tree/master/app/cogs/autoreact)<br>Keyword auto-reactions |
-| [TextGen](https://github.com/NateShoffner/lanco-discord-bot/tree/master/app/cogs/textgen)<br>Text generator | [Bot](https://github.com/NateShoffner/lanco-discord-bot/tree/master/app/cogs/bot)<br>Bot configuration | [FileFixer](https://github.com/NateShoffner/lanco-discord-bot/tree/master/app/cogs/filefixer)<br>Attempt to fix files |
-| [Weather](https://github.com/NateShoffner/lanco-discord-bot/tree/master/app/cogs/weather)<br>Weather lookup | [Commands](https://github.com/NateShoffner/lanco-discord-bot/tree/master/app/cogs/commands)<br>Custom guild commands | [Paywall Bypass](https://github.com/NateShoffner/lanco-discord-bot/tree/master/app/cogs/paywallbypass)<br>Bypass paywalls |
-| [Genshin](https://github.com/NateShoffner/lanco-discord-bot/tree/master/app/cogs/genshin)<br>Genshin Impact commands | [Anime](https://github.com/NateShoffner/lanco-discord-bot/tree/master/app/cogs/anime)<br>Anime commands | [CoinFlip](https://github.com/NateShoffner/lanco-discord-bot/tree/master/app/cogs/CoinFlip)<br>Flip a coin |
-| [Facts](https://github.com/NateShoffner/lanco-discord-bot/tree/master/app/cogs/facts)<br>Random facts | [dadjoke](https://github.com/NateShoffner/lanco-discord-bot/tree/master/app/cogs/dadjoke)<br>Dad jokes | [Transcribe](https://github.com/NateShoffner/lanco-discord-bot/tree/master/app/cogs/transcribe)<br>Transcribe audio files |
-| [ADHDChannel](https://github.com/NateShoffner/lanco-discord-bot/tree/master/app/cogs/adhdchannel)<br>Dynamic channel topic updates | [Incidents](https://github.com/NateShoffner/lanco-discord-bot/tree/master/app/cogs/incidents)<br>LCWC incident feed | [TikTok Embed Fix](https://github.com/NateShoffner/lanco-discord-bot/tree/master/app/cogs/tiktokembed)<br>Fix TikTok embeds |
-| [OpenAIPrompts](https://github.com/NateShoffner/lanco-discord-bot/tree/master/app/cogs/aiprompts)<br>AI-powered prompts | [Astrology](https://github.com/NateShoffner/lanco-discord-bot/tree/master/app/cogs/astrology)<br>Astrology commands | [Whisper](https://github.com/NateShoffner/lanco-discord-bot/tree/master/app/cogs/whisper)<br>Whisper transcription |
-| [RSSFeed](https://github.com/NateShoffner/lanco-discord-bot/tree/master/app/cogs/rssfeed)<br>RSS feed polling | [RemindMe](https://github.com/NateShoffner/lanco-discord-bot/tree/master/app/cogs/remindme)<br>Set reminders | [Counter](https://github.com/NateShoffner/lanco-discord-bot/tree/master/app/cogs/counter)<br>Counting channel |
-| [ScheduledPost](https://github.com/NateShoffner/lanco-discord-bot/tree/master/app/cogs/ScheduledPost)<br>Schedule recurring posts | | |
+- [ADHDChannel](app/cogs/adhdchannel) — Dynamic channel topic updates
+- [AIDetection](app/cogs/AIDetection) — Detect AI-generated content
+- [Admin](app/cogs/admin) — Admin commands
+- [Anime](app/cogs/anime) — Anime info lookup
+- [AnimeToday](app/cogs/animetoday) — Daily anime announcements
+- [Astrology](app/cogs/astrology) — Horoscope readings
+- [AutoReact](app/cogs/autoreact) — Keyword auto-reactions
+- [AutoResponse](app/cogs/autoresponse) — Keyword auto-responses
+- [BarHopper](app/cogs/barhopper) — Bar hopper commands
+- [Birthday](app/cogs/birthday) — Birthday announcements
+- [Bot](app/cogs/bot) — Bot configuration
+- [ChatBot](app/cogs/chatbot) — AI chatbot with per-user memory
+- [ChatRelay](app/cogs/chatrelay) — Cross-server message relay
+- [CoinFlip](app/cogs/CoinFlip) — Flip a coin
+- [Commands](app/cogs/commands) — Custom guild commands
+- [Conversions](app/cogs/conversions) — Unit conversions
+- [Counter](app/cogs/counter) — Counting channel game
+- [DadJoke](app/cogs/dadjoke) — Dad jokes
+- [DatabaseBackupper](app/cogs/databasebackupper) — Scheduled DB backups
+- [Describe](app/cogs/describe) — Describe images via context menu
+- [EmoteTools](app/cogs/emotetools) — Emote and sticker tools
+- [Everbridge](app/cogs/everbridge) — Everbridge alerts
+- [Facts](app/cogs/facts) — Random facts
+- [FileFixer](app/cogs/filefixer) — Convert unsupported file types
+- [Fishbowl](app/cogs/fishbowl) — Auto-expiring message channels
+- [FixIt](app/cogs/fixit) — SeeClickFix issue feed
+- [FortuneCookie](app/cogs/fortunecookie) — Fortune cookies
+- [Fun](app/cogs/fun) — Fun commands
+- [GameStats](app/cogs/gamestats) — Server game statistics
+- [GeoGuesser](app/cogs/geoguesser) — Lancaster-themed GeoGuesser
+- [Genshin](app/cogs/genshin) — Genshin Impact commands
+- [Google](app/cogs/google) — Google search links
+- [HotDog](app/cogs/hotdog) — Profile glizzies
+- [Incidents](app/cogs/incidents) — LCWC incident feed
+- [InstaEmbed](app/cogs/instaembed) — Instagram embed fix
+- [Magic8Ball](app/cogs/magic8ball) — Magic 8 Ball
+- [MarkSafe](app/cogs/marksafe) — Mark yourself safe/unsafe
+- [NewsHeadlines](app/cogs/newsheadlines) — News headlines
+- [NutCheck](app/cogs/nutcheck) — No Nut November tracker
+- [OneWordStory](app/cogs/onewordstory) — Collaborative one-word story
+- [OpenAIPrompts](app/cogs/aiprompts) — AI-powered prompts
+- [PaywallBypass](app/cogs/paywallbypass) — Bypass Lancaster Online paywall
+- [PDFPreview](app/cogs/pdfpreview) — PDF preview generation
+- [PeeCheck](app/cogs/peecheck) — Hydration tracker
+- [PetTax](app/cogs/pettax) — Pet tax enforcement
+- [Pinboard](app/cogs/pinboard) — Personal message pinboard
+- [Profile](app/cogs/profile) — Custom user profiles
+- [RandomNSFWReddit](app/cogs/randomnsfwreddit) — Random NSFW subreddits
+- [ReactTrack](app/cogs/reacttrack) — Reaction analytics
+- [RedditEmbed](app/cogs/redditembed) — Reddit embed fix
+- [RedditFeed](app/cogs/redditfeed) — Subreddit feed polling
+- [RemindMe](app/cogs/remindme) — Set reminders
+- [RoleStats](app/cogs/rolestats) — Server role statistics
+- [RSSFeed](app/cogs/rssfeed) — RSS feed polling
+- [ScheduledPost](app/cogs/ScheduledPost) — Schedule recurring posts
+- [SleepCheck](app/cogs/sleepcheck) — Sleep hour leaderboard
+- [SpotifyDaylist](app/cogs/spotifydaylist) — Spotify daylist tracking
+- [SpotifyEmbed](app/cogs/spotifyembed) — Spotify embed fix
+- [SpyDotPet](app/cogs/spydotpet) — Detect suspicious bots
+- [Summarize](app/cogs/summarize) — Channel topic and vibe summaries
+- [System](app/cogs/system) — Bot status and admin info
+- [TextGen](app/cogs/textgen) — Text effects (zalgo, etc.)
+- [TikTokEmbed](app/cogs/tiktokembed) — TikTok embed fix
+- [TipCalc](app/cogs/tipcalc) — Tip calculator
+- [TraceMoe](app/cogs/tracemoe) — Identify anime from screenshots
+- [Transcribe](app/cogs/transcribe) — Transcribe audio files
+- [TruthSocial](app/cogs/TruthSocial) — TruthSocial embed support
+- [Twitter/X Embed](app/cogs/twitterembed) — Twitter/X embed fix
+- [User](app/cogs/user) — User opt-in/opt-out
+- [Verification](app/cogs/verification) — Vote-based member verification
+- [Weather](app/cogs/weather) — Weather lookup
+- [WebPreview](app/cogs/webpreview) — Web link previews
+- [WebServer](app/cogs/webserver) — Embedded status web server
+- [Whisper](app/cogs/whisper) — Send private messages
+- [WolframAlpha](app/cogs/wolframalpha) — Wolfram Alpha queries
+- [YouTube](app/cogs/youtube) — YouTube channel feed polling
 
 ## 🚀 Installation
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,15 @@ poetry run cog create --name MyCog --description "My description"
 
 ```bash
 mkdir app/cogs/yourcog
+touch app/cogs/yourcog/__init__.py
 touch app/cogs/yourcog/yourcog.py
+```
+
+Each cog directory must have an `__init__.py` that re-exports `setup`:
+
+```python
+# app/cogs/yourcog/__init__.py
+from .yourcog import setup
 ```
 
 All cogs inherit from `LancoCog`:
@@ -118,6 +126,10 @@ from discord.ext import commands
 class YourCog(LancoCog, name="YourCog", description="Your cog description."):
     def __init__(self, bot: commands.Bot):
         super().__init__(bot)
+
+    async def cog_load(self):
+        await super().cog_load()
+        # initialize tables, start tasks, etc.
 
 async def setup(bot):
     await bot.add_cog(YourCog(bot))

--- a/app/cogs/AIDetection/__init__.py
+++ b/app/cogs/AIDetection/__init__.py
@@ -1,0 +1,1 @@
+from .AIDetection import setup

--- a/app/cogs/CoinFlip/__init__.py
+++ b/app/cogs/CoinFlip/__init__.py
@@ -1,0 +1,1 @@
+from .CoinFlip import setup

--- a/app/cogs/JeffVacation/README.md
+++ b/app/cogs/JeffVacation/README.md
@@ -1,0 +1,9 @@
+# JeffVacation
+
+Displays a countdown to the end of Jeff's vacation with a Dawn Screen-style ASCII art image.
+
+## Commands
+
+| Command | Description |
+|---|---|
+| `!vacation` | Show vacation countdown |

--- a/app/cogs/JeffVacation/__init__.py
+++ b/app/cogs/JeffVacation/__init__.py
@@ -1,0 +1,1 @@
+from .JeffVacation import setup

--- a/app/cogs/JiraHate/__init__.py
+++ b/app/cogs/JiraHate/__init__.py
@@ -1,0 +1,1 @@
+from .JiraHate import setup

--- a/app/cogs/PasswordGenerator/__init__.py
+++ b/app/cogs/PasswordGenerator/__init__.py
@@ -1,0 +1,1 @@
+from .PasswordGenerator import setup

--- a/app/cogs/ScheduledPost/__init__.py
+++ b/app/cogs/ScheduledPost/__init__.py
@@ -1,0 +1,1 @@
+from .ScheduledPost import setup

--- a/app/cogs/TechLanc/__init__.py
+++ b/app/cogs/TechLanc/__init__.py
@@ -1,0 +1,1 @@
+from .TechLanc import setup

--- a/app/cogs/TruthSocial/__init__.py
+++ b/app/cogs/TruthSocial/__init__.py
@@ -1,0 +1,1 @@
+from .TruthSocial import setup

--- a/app/cogs/adhdchannel/README.md
+++ b/app/cogs/adhdchannel/README.md
@@ -1,0 +1,13 @@
+# ADHDChannel
+
+Automatically renames a channel and updates its topic based on live conversation content, using AI to detect what's currently being discussed.
+
+## Commands
+
+| Command | Description | Permissions |
+|---|---|---|
+| `/adhd toggle` | Enable or disable ADHD channel tracking for the current channel | Admin only |
+
+## Configuration
+
+Requires `OPENAI_API_KEY`. Channel names update every 30 seconds while enabled.

--- a/app/cogs/adhdchannel/__init__.py
+++ b/app/cogs/adhdchannel/__init__.py
@@ -1,0 +1,1 @@
+from .adhdchannel import setup

--- a/app/cogs/adhdchannel/adhdchannel.py
+++ b/app/cogs/adhdchannel/adhdchannel.py
@@ -36,9 +36,8 @@ class ADHDChannel(
             output_type=ChannelDiscussion,
         )
 
-    @commands.Cog.listener()
-    async def on_ready(self):
-        await super().on_ready()
+    async def cog_load(self):
+        await super().cog_load()
         self.update_channel_name.change_interval(seconds=30)
         self.update_channel_name.start()
 

--- a/app/cogs/admin/README.md
+++ b/app/cogs/admin/README.md
@@ -1,0 +1,10 @@
+# Admin
+
+Basic message management commands.
+
+## Commands
+
+| Command | Description | Permissions |
+|---|---|---|
+| `!delete` | Delete a replied-to message | Admin only |
+| `/admin delete <message_id>` | Delete a message by ID | Admin only |

--- a/app/cogs/admin/__init__.py
+++ b/app/cogs/admin/__init__.py
@@ -1,0 +1,1 @@
+from .admin import setup

--- a/app/cogs/aiprompts/README.md
+++ b/app/cogs/aiprompts/README.md
@@ -1,0 +1,23 @@
+# AI Prompts
+
+Manage custom AI prompts that server members can trigger via prefix commands. Each prompt is stored per-guild and executed against OpenAI.
+
+## Commands
+
+| Command | Description | Permissions |
+|---|---|---|
+| `/aiprompt add` | Add a new AI prompt | Admin only |
+| `/aiprompt edit <name>` | Edit an existing prompt | Admin only |
+| `/aiprompt remove <name>` | Remove a prompt | Admin only |
+| `/aiprompt list` | List all prompts for this server | — |
+| `!<prompt_name> <text>` | Execute a custom prompt | — |
+
+## Configuration
+
+Requires `OPENAI_API_KEY`.
+
+## Database
+
+| Table | Purpose |
+|---|---|
+| `ai_prompt_configs` | Stores prompt name, text, and guild association |

--- a/app/cogs/aiprompts/__init__.py
+++ b/app/cogs/aiprompts/__init__.py
@@ -1,0 +1,1 @@
+from .aiprompts import setup

--- a/app/cogs/anime/__init__.py
+++ b/app/cogs/anime/__init__.py
@@ -1,0 +1,1 @@
+from .anime import setup

--- a/app/cogs/animetoday/__init__.py
+++ b/app/cogs/animetoday/__init__.py
@@ -1,0 +1,1 @@
+from .animetoday import setup

--- a/app/cogs/astrology/__init__.py
+++ b/app/cogs/astrology/__init__.py
@@ -1,0 +1,1 @@
+from .astrology import setup

--- a/app/cogs/autoreact/__init__.py
+++ b/app/cogs/autoreact/__init__.py
@@ -1,0 +1,1 @@
+from .autoreact import setup

--- a/app/cogs/autoresponse/__init__.py
+++ b/app/cogs/autoresponse/__init__.py
@@ -1,0 +1,1 @@
+from .autoresponse import setup

--- a/app/cogs/barhopper/README.md
+++ b/app/cogs/barhopper/README.md
@@ -1,0 +1,21 @@
+# BarHopper
+
+Search and discover bars using Google Maps. Supports browsing by name or getting random suggestions, with cached map images and ratings.
+
+## Commands
+
+| Command | Description | Permissions |
+|---|---|---|
+| `/barhopper populate` | Populate the database with bars from Google Maps | Owner only |
+| `/barhopper search <term>` | Search bars by name | — |
+| `/barhopper random [count]` | Get random bar suggestions (max 5) | — |
+
+## Configuration
+
+Requires `GMAPS_API_KEY`.
+
+## Database
+
+| Table | Purpose |
+|---|---|
+| `bars` | Bar details including name, address, coordinates, rating, price level, and place ID |

--- a/app/cogs/barhopper/__init__.py
+++ b/app/cogs/barhopper/__init__.py
@@ -1,0 +1,1 @@
+from .barhopper import setup

--- a/app/cogs/birthday/__init__.py
+++ b/app/cogs/birthday/__init__.py
@@ -1,0 +1,1 @@
+from .birthday import setup

--- a/app/cogs/bot/README.md
+++ b/app/cogs/bot/README.md
@@ -1,0 +1,12 @@
+# Bot
+
+Bot configuration commands for managing activity status, nickname, and command prefix.
+
+## Commands
+
+| Command | Description | Permissions |
+|---|---|---|
+| `/activity <type> <text>` | Set bot activity (playing/listening/watching) | Owner only |
+| `/setname <name>` | Change the bot's nickname in the guild | Admin only |
+| `/setprefix <prefix>` | Set the command prefix for this guild (max 2 chars) | Admin only |
+| `/prefix` | Show the current command prefix | — |

--- a/app/cogs/bot/__init__.py
+++ b/app/cogs/bot/__init__.py
@@ -1,0 +1,1 @@
+from .bot import setup

--- a/app/cogs/chatbot/__init__.py
+++ b/app/cogs/chatbot/__init__.py
@@ -1,0 +1,1 @@
+from .chatbot import setup

--- a/app/cogs/chatrelay/README.md
+++ b/app/cogs/chatrelay/README.md
@@ -1,0 +1,9 @@
+# ChatRelay
+
+Relays incoming DMs to a configured guild channel.
+
+## Commands
+
+| Command | Description | Permissions |
+|---|---|---|
+| `!relay <channel_id>` | Set the channel to relay DMs to | Owner only |

--- a/app/cogs/chatrelay/__init__.py
+++ b/app/cogs/chatrelay/__init__.py
@@ -1,0 +1,1 @@
+from .chatrelay import setup

--- a/app/cogs/commands/__init__.py
+++ b/app/cogs/commands/__init__.py
@@ -1,0 +1,1 @@
+from .commands import setup

--- a/app/cogs/conversions/README.md
+++ b/app/cogs/conversions/README.md
@@ -1,0 +1,9 @@
+# Conversions
+
+Unit conversion utilities.
+
+## Commands
+
+| Command | Description |
+|---|---|
+| `/conversion temperature <value> <unit>` | Convert between Celsius and Fahrenheit |

--- a/app/cogs/conversions/__init__.py
+++ b/app/cogs/conversions/__init__.py
@@ -1,0 +1,1 @@
+from .conversions import setup

--- a/app/cogs/counter/__init__.py
+++ b/app/cogs/counter/__init__.py
@@ -1,0 +1,1 @@
+from .counter import setup

--- a/app/cogs/dadjoke/README.md
+++ b/app/cogs/dadjoke/README.md
@@ -1,0 +1,9 @@
+# DadJoke
+
+Detects "I'm [name]" messages and responds with a dad joke, temporarily renaming the user for 10 seconds.
+
+## Commands
+
+| Command | Description | Permissions |
+|---|---|---|
+| `/dadjoke toggle` | Enable or disable dad jokes in this channel | Admin only |

--- a/app/cogs/dadjoke/__init__.py
+++ b/app/cogs/dadjoke/__init__.py
@@ -1,0 +1,1 @@
+from .dadjoke import setup

--- a/app/cogs/demo/__init__.py
+++ b/app/cogs/demo/__init__.py
@@ -1,0 +1,1 @@
+from .demo import setup

--- a/app/cogs/describe/__init__.py
+++ b/app/cogs/describe/__init__.py
@@ -1,0 +1,1 @@
+from .describe import setup

--- a/app/cogs/emotetools/README.md
+++ b/app/cogs/emotetools/README.md
@@ -1,0 +1,9 @@
+# EmoteTools
+
+Inspect emotes and stickers used in messages.
+
+## Commands
+
+| Command | Description |
+|---|---|
+| Context menu: "Emote Details" | Shows emote/sticker ID, URL, and animation status for a message |

--- a/app/cogs/emotetools/__init__.py
+++ b/app/cogs/emotetools/__init__.py
@@ -1,0 +1,1 @@
+from .emotetools import setup

--- a/app/cogs/everbridge/__init__.py
+++ b/app/cogs/everbridge/__init__.py
@@ -1,0 +1,1 @@
+from .everbridge import setup

--- a/app/cogs/facts/README.md
+++ b/app/cogs/facts/README.md
@@ -1,0 +1,16 @@
+# Facts
+
+Store and retrieve server-specific facts.
+
+## Commands
+
+| Command | Description | Permissions |
+|---|---|---|
+| `/fact add [fact_id]` | Add or edit a fact (omit ID to create new) | Admin only |
+| `!fact` | Get a random fact from this server | — |
+
+## Database
+
+| Table | Purpose |
+|---|---|
+| `facts` | Stores fact text, author, guild, and last modified timestamp |

--- a/app/cogs/facts/__init__.py
+++ b/app/cogs/facts/__init__.py
@@ -1,0 +1,1 @@
+from .facts import setup

--- a/app/cogs/filefixer/__init__.py
+++ b/app/cogs/filefixer/__init__.py
@@ -1,0 +1,1 @@
+from .filefixer import setup

--- a/app/cogs/fishbowl/__init__.py
+++ b/app/cogs/fishbowl/__init__.py
@@ -1,0 +1,1 @@
+from .fishbowl import setup

--- a/app/cogs/fixit/__init__.py
+++ b/app/cogs/fixit/__init__.py
@@ -1,0 +1,1 @@
+from .fixit import setup

--- a/app/cogs/fortunecookie/__init__.py
+++ b/app/cogs/fortunecookie/__init__.py
@@ -1,0 +1,1 @@
+from .fortunecookie import setup

--- a/app/cogs/fun/README.md
+++ b/app/cogs/fun/README.md
@@ -1,0 +1,9 @@
+# Fun
+
+Miscellaneous text effects.
+
+## Commands
+
+| Command | Description |
+|---|---|
+| `/fun clap <text>` | Add 👏 clap emojis between words |

--- a/app/cogs/fun/__init__.py
+++ b/app/cogs/fun/__init__.py
@@ -1,0 +1,1 @@
+from .fun import setup

--- a/app/cogs/gamestats/__init__.py
+++ b/app/cogs/gamestats/__init__.py
@@ -1,0 +1,1 @@
+from .gamestats import setup

--- a/app/cogs/genshin/README.md
+++ b/app/cogs/genshin/README.md
@@ -1,0 +1,3 @@
+# Genshin
+
+Reacts with ⚠️ whenever "genshin" is mentioned in chat.

--- a/app/cogs/genshin/__init__.py
+++ b/app/cogs/genshin/__init__.py
@@ -1,0 +1,1 @@
+from .genshin import setup

--- a/app/cogs/geoguesser/__init__.py
+++ b/app/cogs/geoguesser/__init__.py
@@ -1,0 +1,1 @@
+from .geoguesser import setup

--- a/app/cogs/google/__init__.py
+++ b/app/cogs/google/__init__.py
@@ -1,0 +1,1 @@
+from .google import setup

--- a/app/cogs/hotdog/README.md
+++ b/app/cogs/hotdog/README.md
@@ -1,0 +1,14 @@
+# HotDog
+
+AI-powered image classifier that determines whether an image contains a hot dog.
+
+## Commands
+
+| Command | Description |
+|---|---|
+| Context menu: "Hot Dog" | Classify the image in a message |
+| `!hotdog` | Reply to a message with an image to classify |
+
+## Configuration
+
+Requires `OPENAI_API_KEY` (uses GPT-4o vision).

--- a/app/cogs/hotdog/__init__.py
+++ b/app/cogs/hotdog/__init__.py
@@ -1,0 +1,1 @@
+from .hotdog import setup

--- a/app/cogs/incidents/__init__.py
+++ b/app/cogs/incidents/__init__.py
@@ -1,0 +1,1 @@
+from .incidents import setup

--- a/app/cogs/incidents/incidents.py
+++ b/app/cogs/incidents/incidents.py
@@ -70,9 +70,8 @@ class Incidents(LancoCog, name="Incidents", description="LCWC Incident feed"):
         self.last_sync_attempt = None
         self.last_successful_sync = None
 
-    @commands.Cog.listener()
-    async def on_ready(self):
-        await super().on_ready()
+    async def cog_load(self):
+        await super().cog_load()
         self.get_incidents_loop.change_interval(seconds=5)
         self.get_incidents_loop.start()
 

--- a/app/cogs/instaembed/__init__.py
+++ b/app/cogs/instaembed/__init__.py
@@ -1,0 +1,1 @@
+from .instaembed import setup

--- a/app/cogs/lancocog.py
+++ b/app/cogs/lancocog.py
@@ -1,35 +1,11 @@
 import inspect
 import logging
-import os
 import re
-from dataclasses import dataclass
+from pathlib import Path
 
 from discord import app_commands
 from discord.ext import commands
 from pydantic import BaseModel
-
-
-@dataclass
-class CogDefinition:
-    """Represents file-system information about a cog"""
-
-    path: str
-    """ The path to the cog directory  """
-    name: str
-    """ The file-system name of the cog"""
-    qualified_name: str
-    """ The fully qualified name of the cog (dot-separated path) """
-    entry_point: str
-    """ The entry point script for the cog"""
-
-
-def get_cog_def(name: str, cogs_dir: str) -> CogDefinition:
-    """Get the cog definition for a cog based on the cog name and the cogs directory"""
-    path = os.path.normpath(os.path.join(cogs_dir, name))
-    cogs_dir_name = os.path.basename(cogs_dir)
-    qualified_name = f"{cogs_dir_name}.{name}.{name}"
-    entry_point = os.path.normpath(f"{path}/{name}.py")
-    return CogDefinition(path, name, qualified_name, entry_point)
 
 
 class LancoCog(commands.Cog, name="LancoCog", description="Base class for all cogs"):
@@ -41,7 +17,6 @@ class LancoCog(commands.Cog, name="LancoCog", description="Base class for all co
         super().__init__(*args, **kwargs)
         self._bot = bot
         self.logger = logging.getLogger(self.get_cog_name())
-        self.cog_def = None
         self.context_menus = []
         self._tracked_tasks = []
 
@@ -50,52 +25,25 @@ class LancoCog(commands.Cog, name="LancoCog", description="Base class for all co
         self._tracked_tasks.append(task)
         return task
 
-    def set_cog_def(self, cog_def: CogDefinition):
-        """Set the cog definition"""
-        self.cog_def = cog_def
-
-    @commands.Cog.listener()
-    async def on_ready(self):
+    async def cog_load(self):
         self.logger.info(f"{self.get_cog_name()} cog loaded")
 
     def get_cog_name(self):
-        """Get the name of the cog"""
         return self.qualified_name
 
-    def get_class_name(self):
-        """Get the class name of the cog"""
-        return self.__class__.__name__
-
     def get_cog_data_directory(self):
-        """Get the data directory for the cog"""
         return f"data/{self.get_cog_name()}"
 
-    def get_cog_file_path(self, relative: bool = False):
-        """Get the file path for the cog"""
-        path = inspect.getfile(self.__class__)
+    def get_cog_file_path(self, relative: bool = False) -> Path:
+        path = Path(inspect.getfile(self.__class__))
         if relative:
-            path = os.path.relpath(path)
-            # remove top-level directory
-            path = os.path.join(*path.split(os.sep)[1:])
+            path = path.relative_to(Path.cwd() / "app")
         return path
 
-    def get_cog_directory(self, relative: bool = False):
-        """Get the directory for the cog"""
-        path = os.path.dirname(self.get_cog_file_path())
-        if relative:
-            path = os.path.relpath(path)
-            # remove top-level directory
-            path = os.path.join(*path.split(os.sep)[1:])
-        return path
-
-    def get_dotted_path(self):
-        """Get the dotted path for the cog"""
-        dotted = self.get_cog_file_path(True).replace(os.sep, ".")
-        dotted = dotted.replace(".py", "")
-        return dotted
+    def get_cog_directory(self, relative: bool = False) -> Path:
+        return self.get_cog_file_path(relative).parent
 
     def register_context_menu(self, name: str, callback, errback=None, **kwargs):
-        """Register a context menu for the cog"""
         ctx_menu = app_commands.ContextMenu(name=name, callback=callback, **kwargs)
         if errback:
             ctx_menu.error(errback)
@@ -103,18 +51,15 @@ class LancoCog(commands.Cog, name="LancoCog", description="Base class for all co
         self.context_menus.append(ctx_menu)
 
     async def cog_unload(self):
-        """Unloading the cog"""
         self.logger.info(f"{self.get_cog_name()} cog unloaded")
 
         for task in self._tracked_tasks:
             task.cancel()
         self._tracked_tasks.clear()
 
-        # clean up context menus
         for ctx_menu in self.context_menus:
             self.bot.tree.remove_command(ctx_menu.name, type=ctx_menu.type)
 
-        # unregister url handlers belonging to this cog
         self.bot.url_handlers = [h for h in self.bot.url_handlers if h.cog is not self]
 
 

--- a/app/cogs/magic8ball/README.md
+++ b/app/cogs/magic8ball/README.md
@@ -1,0 +1,9 @@
+# Magic 8-Ball
+
+Ask the magic 8-ball a yes/no question and receive a random response.
+
+## Commands
+
+| Command | Description |
+|---|---|
+| `!8ball <question>` | Ask the magic 8-ball |

--- a/app/cogs/magic8ball/__init__.py
+++ b/app/cogs/magic8ball/__init__.py
@@ -1,0 +1,1 @@
+from .magic8ball import setup

--- a/app/cogs/marksafe/__init__.py
+++ b/app/cogs/marksafe/__init__.py
@@ -1,0 +1,1 @@
+from .marksafe import setup

--- a/app/cogs/newsheadlines/README.md
+++ b/app/cogs/newsheadlines/README.md
@@ -1,0 +1,13 @@
+# NewsHeadlines
+
+Fetch recent news headlines from NewsAPI.
+
+## Commands
+
+| Command | Description |
+|---|---|
+| `!trump` | Get the latest Trump-related news headlines (top 5) |
+
+## Configuration
+
+Requires `NEWSAPI_API_KEY`.

--- a/app/cogs/newsheadlines/__init__.py
+++ b/app/cogs/newsheadlines/__init__.py
@@ -1,0 +1,1 @@
+from .newsheadlines import setup

--- a/app/cogs/nutcheck/README.md
+++ b/app/cogs/nutcheck/README.md
@@ -1,0 +1,9 @@
+# NutCheck
+
+No Nut November tracker. Only active during November. NSFW channels only.
+
+## Commands
+
+| Command | Description |
+|---|---|
+| `!nutcheck` | Mark your NNN status with reaction voting |

--- a/app/cogs/nutcheck/__init__.py
+++ b/app/cogs/nutcheck/__init__.py
@@ -1,0 +1,1 @@
+from .nutcheck import setup

--- a/app/cogs/onewordstory/__init__.py
+++ b/app/cogs/onewordstory/__init__.py
@@ -1,0 +1,1 @@
+from .onewordstory import setup

--- a/app/cogs/paywallbypass/__init__.py
+++ b/app/cogs/paywallbypass/__init__.py
@@ -1,0 +1,1 @@
+from .paywallbypass import setup

--- a/app/cogs/pdfpreview/__init__.py
+++ b/app/cogs/pdfpreview/__init__.py
@@ -1,0 +1,1 @@
+from .pdfpreview import setup

--- a/app/cogs/peecheck/__init__.py
+++ b/app/cogs/peecheck/__init__.py
@@ -1,0 +1,1 @@
+from .peecheck import setup

--- a/app/cogs/pinboard/__init__.py
+++ b/app/cogs/pinboard/__init__.py
@@ -1,0 +1,1 @@
+from .pinboard import setup

--- a/app/cogs/profile/__init__.py
+++ b/app/cogs/profile/__init__.py
@@ -1,0 +1,1 @@
+from .profile import setup

--- a/app/cogs/randomnsfwreddit/README.md
+++ b/app/cogs/randomnsfwreddit/README.md
@@ -1,0 +1,15 @@
+# RandomNSFWReddit
+
+Browse random NSFW subreddits from a curated cache sourced from the NSFW411 wiki. NSFW channels only.
+
+## Commands
+
+| Command | Description |
+|---|---|
+| `!randomnsfw` | Get a random NSFW subreddit |
+| `!nsfw <keyword>` | Search NSFW subreddits by keyword |
+| `!randomnsfwcount` | Show cache stats and last update time |
+
+## Configuration
+
+Requires `REDDIT_ID` and `REDDIT_SECRET`. Cache updates every 6 hours.

--- a/app/cogs/randomnsfwreddit/__init__.py
+++ b/app/cogs/randomnsfwreddit/__init__.py
@@ -1,0 +1,1 @@
+from .randomnsfwreddit import setup

--- a/app/cogs/reacttrack/README.md
+++ b/app/cogs/reacttrack/README.md
@@ -1,0 +1,15 @@
+# ReactTrack
+
+Tracks emoji reactions across the server for analytics.
+
+## Commands
+
+| Command | Description |
+|---|---|
+| `/reacttrack today <user>` | Show a user's reactions in the last 24 hours |
+
+## Database
+
+| Table | Purpose |
+|---|---|
+| `react_events` | Logs reaction add/remove events with emoji, user, channel, and timestamp |

--- a/app/cogs/reacttrack/__init__.py
+++ b/app/cogs/reacttrack/__init__.py
@@ -1,0 +1,1 @@
+from .reacttrack import setup

--- a/app/cogs/redditembed/__init__.py
+++ b/app/cogs/redditembed/__init__.py
@@ -1,0 +1,1 @@
+from .redditembed import setup

--- a/app/cogs/redditfeed/__init__.py
+++ b/app/cogs/redditfeed/__init__.py
@@ -1,0 +1,1 @@
+from .redditfeed import setup

--- a/app/cogs/remindme/__init__.py
+++ b/app/cogs/remindme/__init__.py
@@ -1,0 +1,1 @@
+from .remindme import setup

--- a/app/cogs/rolestats/README.md
+++ b/app/cogs/rolestats/README.md
@@ -1,0 +1,9 @@
+# RoleStats
+
+Display member statistics for a role.
+
+## Commands
+
+| Command | Description |
+|---|---|
+| `/rolestats stats <role>` | Show member count and list for a role |

--- a/app/cogs/rolestats/__init__.py
+++ b/app/cogs/rolestats/__init__.py
@@ -1,0 +1,1 @@
+from .rolestats import setup

--- a/app/cogs/rssfeed/README.md
+++ b/app/cogs/rssfeed/README.md
@@ -1,0 +1,16 @@
+# RSSFeed
+
+Polls RSS feeds for new items and posts them to subscribed channels.
+
+## Commands
+
+| Command | Description |
+|---|---|
+| `/rssfeed subscribe <url>` | Subscribe a channel to an RSS feed |
+| `/rssfeed unsubscribe <url>` | Unsubscribe from an RSS feed |
+
+## Database
+
+| Table | Purpose |
+|---|---|
+| `rss_feed_configs` | Per-channel RSS subscriptions |

--- a/app/cogs/rssfeed/__init__.py
+++ b/app/cogs/rssfeed/__init__.py
@@ -1,0 +1,1 @@
+from .rssfeed import setup

--- a/app/cogs/sleepcheck/README.md
+++ b/app/cogs/sleepcheck/README.md
@@ -1,0 +1,9 @@
+# SleepCheck
+
+Analyzes sleep tracker screenshots to determine sleep hours and create leaderboards.
+
+## Commands
+
+| Command | Description |
+|---|---|
+| `/sleepcheck today` | Show how much sleep everyone got today |

--- a/app/cogs/sleepcheck/__init__.py
+++ b/app/cogs/sleepcheck/__init__.py
@@ -1,0 +1,1 @@
+from .sleepcheck import setup

--- a/app/cogs/spotifyembed/__init__.py
+++ b/app/cogs/spotifyembed/__init__.py
@@ -1,0 +1,1 @@
+from .spotifyembed import setup

--- a/app/cogs/spydotpet/README.md
+++ b/app/cogs/spydotpet/README.md
@@ -1,0 +1,9 @@
+# SpyDotPet
+
+Checks for suspicious bots in the server using the kickthespy.pet API.
+
+## Commands
+
+| Command | Description |
+|---|---|
+| `!botcheck` | Check for loser bots in the server |

--- a/app/cogs/spydotpet/__init__.py
+++ b/app/cogs/spydotpet/__init__.py
@@ -1,0 +1,1 @@
+from .spydotpet import setup

--- a/app/cogs/summarize/README.md
+++ b/app/cogs/summarize/README.md
@@ -1,0 +1,12 @@
+# Summarize
+
+Analyzes recent channel messages to extract trending topics, vibe checks, and AI-generated summaries.
+
+## Commands
+
+| Command | Description |
+|---|---|
+| `!topic` | What the current channel is talking about |
+| `!vibecheck` | Vibe check of the current channel |
+| `!eli5` | ELI5 explanation of the channel vibe |
+| `!chime` | Chime in on the current conversation |

--- a/app/cogs/summarize/__init__.py
+++ b/app/cogs/summarize/__init__.py
@@ -1,0 +1,1 @@
+from .summarize import setup

--- a/app/cogs/system/README.md
+++ b/app/cogs/system/README.md
@@ -1,0 +1,15 @@
+# System
+
+System and admin commands for monitoring bot status, network, and database info.
+
+## Commands
+
+| Command | Description | Permissions |
+|---|---|---|
+| `/ping` | Ping the bot | — |
+| `/info` | Show bot info and version | — |
+| `/cogs` | List loaded cogs | — |
+| `/netstats` | Show network stats | — |
+| `/dbinfo` | Show database info | Admin only |
+| `/block <user>` | Block a user from using the bot | Admin only |
+| `/unblock <user>` | Unblock a blocked user | Admin only |

--- a/app/cogs/system/__init__.py
+++ b/app/cogs/system/__init__.py
@@ -1,0 +1,1 @@
+from .system import setup

--- a/app/cogs/system/system.py
+++ b/app/cogs/system/system.py
@@ -1,0 +1,218 @@
+import datetime
+import os
+from sys import version_info as sysv
+from time import monotonic
+
+import discord
+import psutil
+from cogs.lancocog import LancoCog
+from discord.ext import commands
+from utils.command_utils import is_bot_owner
+from utils.dist_utils import get_bot_version, get_commit_hash
+from utils.network_utils import get_external_ip
+
+
+class SystemCog(LancoCog, name="SystemCog", description="System and admin commands"):
+    def __init__(self, bot: commands.Bot):
+        super().__init__(bot)
+
+    @discord.app_commands.command(name="ping", description="Ping the bot")
+    async def ping(self, interaction: discord.Interaction):
+        lat = round(self.bot.latency * 1000)
+        embed = discord.Embed(title="🏓 Pong!", color=0x00FF00)
+        embed.add_field(name="Bot Latency", value=f"{lat}ms", inline=False)
+
+        start = monotonic()
+        msg = await interaction.response.send_message(embed=embed)
+        end = monotonic()
+
+        response_msg = await interaction.original_response()
+        embed.add_field(
+            name="Message Latency",
+            value=f"{round((end - start) * 1000)}ms",
+            inline=False,
+        )
+        await response_msg.edit(embed=embed)
+
+    @discord.app_commands.command(name="info", description="Show bot info")
+    async def info(self, interaction: discord.Interaction):
+        info = await self.bot.application_info()
+
+        desc = f"{self.bot.user.name} is a general-purpose Discord bot tailored for Lancaster County, PA Discord servers.\n\n"
+        links = {
+            "Homepage": "https://lancobot.dev",
+            "GitHub": "https://github.com/NateShoffner/lanco-discord-bot",
+            "Privacy Policy": "https://lancobot.dev/privacy",
+            "Terms of Service": "https://lancobot.dev/terms",
+        }
+        for name, url in links.items():
+            desc += f"[{name}]({url})\n"
+
+        embed = discord.Embed(
+            title=f"{self.bot.user.name} Info", description=desc, color=0x00FF00
+        )
+
+        users = len(self.bot.users)
+        unique_users = sum(len(g.members) for g in self.bot.guilds)
+        channels = list(self.bot.get_all_channels())
+        text_channels = sum(1 for c in channels if isinstance(c, discord.TextChannel))
+        voice_channels = sum(1 for c in channels if isinstance(c, discord.VoiceChannel))
+
+        uptime = datetime.datetime.now() - self.bot.start_time
+        uptime_str = f"{uptime.days}d {uptime.seconds // 3600}h {(uptime.seconds // 60) % 60}m {uptime.seconds % 60}s"
+
+        memory_usage = cpu_usage = "N/A"
+        pid = None
+        try:
+            pid = os.getpid()
+            process = psutil.Process(pid)
+            memory_usage = f"{process.memory_info().rss / 1024 / 1024:.2f} MB"
+            cpu_usage = f"{psutil.cpu_percent(interval=1)}%"
+        except Exception as e:
+            self.logger.error(f"Failed to get memory/cpu usage: {e}")
+
+        owner_str = "Unknown"
+        if info.owner:
+            owner_str = info.owner.name
+        if info.team:
+            owner_str = info.team.name
+
+        application_emojis = await self.bot.fetch_application_emojis()
+
+        embed.add_field(
+            name="Servers",
+            value=f"Total: {len(self.bot.guilds)}\nShards: {self.bot.shard_count or 1}",
+        )
+        embed.add_field(name="Users", value=f"Total: {users}\nUnique: {unique_users}")
+        embed.add_field(
+            name="Channels",
+            value=f"Total: {len(channels)}\nText: {text_channels}\nVoice: {voice_channels}",
+        )
+        embed.add_field(
+            name="Commands",
+            value=f"Normal: {len(self.bot.commands)}\nSlash: {len(self.bot.tree.get_commands())}",
+        )
+        embed.add_field(
+            name="Assets",
+            value=f"Emojis: {len(self.bot.emojis)}\nApp Emojis: {len(application_emojis)}\nStickers: {len(self.bot.stickers)}",
+        )
+        embed.add_field(
+            name="Process", value=f"RAM: {memory_usage}\nCPU: {cpu_usage}\nPID: {pid}"
+        )
+        embed.add_field(name="Latency", value=f"{round(self.bot.latency * 1000)}ms")
+        embed.add_field(
+            name="Dev Mode", value="Enabled" if self.bot.dev_mode else "Disabled"
+        )
+        embed.add_field(name="Uptime", value=uptime_str)
+        embed.add_field(name="Cogs", value=f"{len(self.bot.get_lanco_cogs())}")
+        embed.add_field(name="Owner", value=owner_str)
+
+        commit = get_commit_hash()
+        github = os.getenv("GITHUB_REPO")
+        if github:
+            embed.add_field(
+                name="Version",
+                value=f"v{get_bot_version()} - [{commit[:7]}]({github}/commit/{commit})",
+            )
+        else:
+            embed.add_field(
+                name="Version", value=f"v{get_bot_version()} - Commit: {commit[:7]}"
+            )
+
+        embed.add_field(name="Message Cache", value=f"{len(self.bot.cached_messages)}")
+        embed.add_field(name="Voice Clients", value=f"{len(self.bot.voice_clients)}")
+        embed.add_field(name="URL Handlers", value=f"{len(self.bot.url_handlers)}")
+
+        embed.set_footer(
+            text=f"Made with ❤️ with Discord.py v{discord.__version__} on Python {sysv.major}.{sysv.minor}.{sysv.micro}",
+            icon_url="https://lancobot.dev/discord.py.png",
+        )
+
+        await interaction.response.send_message(embed=embed)
+
+    @discord.app_commands.command(name="cogs", description="List loaded cogs")
+    async def cogs(self, interaction: discord.Interaction):
+        cogs = self.bot.get_lanco_cogs()
+        cog_list = "\n".join(f"{c.qualified_name} - {c.description}" for c in cogs)
+        embed = discord.Embed(
+            title=f"Loaded Cogs: {len(cogs)}",
+            description=f"```{cog_list}```",
+            color=0x00FF00,
+        )
+        await interaction.response.send_message(embed=embed)
+
+    @discord.app_commands.command(name="netstats", description="Show network stats")
+    async def netstats(self, interaction: discord.Interaction):
+        is_owner = await self.bot.is_owner(interaction.user)
+        ip = await get_external_ip()
+
+        embed = discord.Embed(
+            title="Network Stats", description="Various network stats", color=0x00FF00
+        )
+        embed.add_field(
+            name="External IP", value=ip if is_owner else "🔒 Hidden", inline=False
+        )
+        embed.add_field(
+            name="Latency", value=f"{round(self.bot.latency * 1000)}ms", inline=False
+        )
+        await interaction.response.send_message(embed=embed, ephemeral=True)
+
+    @discord.app_commands.command(name="dbinfo", description="Show database info")
+    @is_bot_owner()
+    async def dbinfo(self, interaction: discord.Interaction):
+        from db import database_proxy
+
+        embed = discord.Embed(title="Database Info", color=0x00FF00)
+
+        db = database_proxy.obj
+        db_size = 0
+        db_type_name = type(db).__name__
+
+        try:
+            if "Sqlite" in db_type_name:
+                db_size = os.path.getsize(db.database)
+            else:
+                cursor = db.execute_sql(
+                    "SELECT SUM(data_length + index_length) FROM information_schema.tables WHERE table_schema = DATABASE();"
+                )
+                db_size = cursor.fetchone()[0] or 0
+        except Exception as e:
+            self.logger.error(f"Failed to get db size: {e}")
+
+        embed.add_field(name="Type", value=db_type_name, inline=False)
+        embed.add_field(
+            name="Size", value=f"{db_size / 1024 / 1024:.2f} MB", inline=False
+        )
+        await interaction.response.send_message(embed=embed, ephemeral=True)
+
+    @discord.app_commands.command(name="block", description="Block a user")
+    @commands.is_owner()
+    async def block(
+        self, interaction: discord.Interaction, user: discord.User, reason: str
+    ):
+        from main import BlacklistedUser
+
+        BlacklistedUser.create(user_id=user.id, reason=reason)
+        await interaction.response.send_message(
+            f"Blocked {user.mention} for {reason}", ephemeral=True
+        )
+
+    @discord.app_commands.command(name="unblock", description="Unblock a user")
+    @commands.is_owner()
+    async def unblock(self, interaction: discord.Interaction, user: discord.User):
+        from main import BlacklistedUser
+
+        u = BlacklistedUser.get_or_none(user_id=user.id)
+        if not u:
+            await interaction.response.send_message(
+                f"{user.mention} is not blocked", ephemeral=True
+            )
+            return
+        u.delete_instance()
+        await interaction.response.send_message(
+            f"Unblocked {user.mention}", ephemeral=True
+        )
+
+
+async def setup(bot: commands.Bot):
+    await bot.add_cog(SystemCog(bot))

--- a/app/cogs/textgen/README.md
+++ b/app/cogs/textgen/README.md
@@ -1,0 +1,9 @@
+# TextGen
+
+Generates stylized text effects.
+
+## Commands
+
+| Command | Description |
+|---|---|
+| `/textgen zalgo <text>` | Generate zalgo (corrupted Unicode) text |

--- a/app/cogs/textgen/__init__.py
+++ b/app/cogs/textgen/__init__.py
@@ -1,0 +1,1 @@
+from .textgen import setup

--- a/app/cogs/tiktokembed/__init__.py
+++ b/app/cogs/tiktokembed/__init__.py
@@ -1,0 +1,1 @@
+from .tiktokembed import setup

--- a/app/cogs/tipcalc/README.md
+++ b/app/cogs/tipcalc/README.md
@@ -1,0 +1,9 @@
+# TipCalc
+
+Calculates tip suggestions from a bill amount or receipt photo.
+
+## Commands
+
+| Command | Description |
+|---|---|
+| `!tip <amount>` | Calculate tip suggestions from a bill amount or receipt photo |

--- a/app/cogs/tipcalc/__init__.py
+++ b/app/cogs/tipcalc/__init__.py
@@ -1,0 +1,1 @@
+from .tipcalc import setup

--- a/app/cogs/tracemoe/__init__.py
+++ b/app/cogs/tracemoe/__init__.py
@@ -1,0 +1,1 @@
+from .tracemoe import setup

--- a/app/cogs/transcribe/__init__.py
+++ b/app/cogs/transcribe/__init__.py
@@ -1,0 +1,1 @@
+from .transcribe import setup

--- a/app/cogs/twitterembed/__init__.py
+++ b/app/cogs/twitterembed/__init__.py
@@ -1,0 +1,1 @@
+from .twitterembed import setup

--- a/app/cogs/user/README.md
+++ b/app/cogs/user/README.md
@@ -1,0 +1,10 @@
+# User
+
+User opt-in/opt-out management for bot interactions.
+
+## Commands
+
+| Command | Description |
+|---|---|
+| `/optout` | Opt out of bot interactions |
+| `/optin` | Opt back in to bot interactions |

--- a/app/cogs/user/__init__.py
+++ b/app/cogs/user/__init__.py
@@ -1,0 +1,1 @@
+from .user import setup

--- a/app/cogs/user/user.py
+++ b/app/cogs/user/user.py
@@ -1,0 +1,37 @@
+import discord
+from cogs.lancocog import LancoCog
+from discord.ext import commands
+from utils.command_utils import is_bot_owner
+
+
+class UserCog(LancoCog, name="UserCog", description="User management commands"):
+    def __init__(self, bot: commands.Bot):
+        super().__init__(bot)
+
+    @discord.app_commands.command(name="optout", description="Opt out of the bot")
+    async def optout(self, interaction: discord.Interaction):
+        from main import BlacklistedUser
+
+        BlacklistedUser.create(user_id=interaction.user.id)
+        await interaction.response.send_message(
+            "You have opted out of the bot.", ephemeral=True
+        )
+
+    @discord.app_commands.command(name="optin", description="Opt in to the bot")
+    async def optin(self, interaction: discord.Interaction):
+        from main import BlacklistedUser
+
+        u = BlacklistedUser.get_or_none(user_id=interaction.user.id)
+        if not u:
+            await interaction.response.send_message(
+                "You are already opted in to the bot.", ephemeral=True
+            )
+            return
+        u.delete_instance()
+        await interaction.response.send_message(
+            "You have opted in to the bot.", ephemeral=True
+        )
+
+
+async def setup(bot: commands.Bot):
+    await bot.add_cog(UserCog(bot))

--- a/app/cogs/verification/README.md
+++ b/app/cogs/verification/README.md
@@ -1,0 +1,20 @@
+# Verification
+
+Vote-based user verification system with configurable role and approval threshold.
+
+## Commands
+
+| Command | Description | Permissions |
+|---|---|---|
+| `/verification verify <user>` | Request verification for a user | — |
+| `/verification unverify <user>` | Remove a user's verification | Admin only |
+| `/verification threshold <n>` | Set vote threshold required for verification | Admin only |
+| `/verification role <role>` | Set the role granted on verification | Admin only |
+| `/verification modchannel <channel>` | Set the mod notification channel | Admin only |
+
+## Database
+
+| Table | Purpose |
+|---|---|
+| `verification_configs` | Per-guild settings (role, threshold, mod channel) |
+| `verification_requests` | Pending and resolved verification requests |

--- a/app/cogs/verification/__init__.py
+++ b/app/cogs/verification/__init__.py
@@ -1,0 +1,1 @@
+from .verification import setup

--- a/app/cogs/weather/__init__.py
+++ b/app/cogs/weather/__init__.py
@@ -1,0 +1,1 @@
+from .weather import setup

--- a/app/cogs/webpreview/README.md
+++ b/app/cogs/webpreview/README.md
@@ -1,0 +1,15 @@
+# WebPreview
+
+Generates rich previews for URLs posted in chat using Open Graph metadata.
+
+## Commands
+
+| Command | Description | Permissions |
+|---|---|---|
+| `/webpreview toggle` | Toggle web previews for this server | Admin only |
+
+## Database
+
+| Table | Purpose |
+|---|---|
+| `web_preview_configs` | Per-guild toggle state |

--- a/app/cogs/webpreview/__init__.py
+++ b/app/cogs/webpreview/__init__.py
@@ -1,0 +1,1 @@
+from .webpreview import setup

--- a/app/cogs/webserver/README.md
+++ b/app/cogs/webserver/README.md
@@ -1,0 +1,11 @@
+# WebServer
+
+Runs an embedded aiohttp web server exposing a bot status endpoint.
+
+## Commands
+
+| Command | Description | Permissions |
+|---|---|---|
+| `/web start` | Start the web server | Admin only |
+| `/web stop` | Stop the web server | Admin only |
+| `/web restart` | Restart the web server | Admin only |

--- a/app/cogs/webserver/__init__.py
+++ b/app/cogs/webserver/__init__.py
@@ -1,0 +1,1 @@
+from .webserver import setup

--- a/app/cogs/whisper/README.md
+++ b/app/cogs/whisper/README.md
@@ -1,0 +1,9 @@
+# Whisper
+
+Send private ephemeral messages to other users within a channel.
+
+## Commands
+
+| Command | Description |
+|---|---|
+| `/w <user> <message>` | Whisper a message to a user |

--- a/app/cogs/whisper/__init__.py
+++ b/app/cogs/whisper/__init__.py
@@ -1,0 +1,1 @@
+from .whisper import setup

--- a/app/cogs/wolframalpha/README.md
+++ b/app/cogs/wolframalpha/README.md
@@ -1,0 +1,13 @@
+# WolframAlpha
+
+Queries Wolfram Alpha for computational answers and factual knowledge.
+
+## Commands
+
+| Command | Description |
+|---|---|
+| `!calc <query>` | Query Wolfram Alpha |
+
+## Configuration
+
+Requires `WOLFRAM_ALPHA_API_KEY`.

--- a/app/cogs/wolframalpha/__init__.py
+++ b/app/cogs/wolframalpha/__init__.py
@@ -1,0 +1,1 @@
+from .wolframalpha import setup

--- a/app/cogs/youtube/README.md
+++ b/app/cogs/youtube/README.md
@@ -1,0 +1,20 @@
+# YouTube
+
+Polls YouTube channels for new videos and posts them to subscribed Discord channels.
+
+## Commands
+
+| Command | Description | Permissions |
+|---|---|---|
+| `/youtube subscribe <channel_id>` | Subscribe to a YouTube channel | Admin only |
+| `/youtube unsubscribe <channel_id>` | Unsubscribe from a YouTube channel | Admin only |
+
+## Configuration
+
+Requires `YOUTUBE_API_KEY`.
+
+## Database
+
+| Table | Purpose |
+|---|---|
+| `youtube_subscriptions` | Per-guild YouTube channel subscriptions |

--- a/app/cogs/youtube/__init__.py
+++ b/app/cogs/youtube/__init__.py
@@ -1,0 +1,1 @@
+from .youtube import setup

--- a/app/main.py
+++ b/app/main.py
@@ -5,22 +5,18 @@ import os
 import shutil
 import sys
 from dataclasses import dataclass
+from enum import Enum, auto
 from logging.handlers import TimedRotatingFileHandler
-from sys import version_info as sysv
-from time import monotonic
 from typing import Optional
 
 import discord
-import psutil
-from cogs.lancocog import CogDefinition, LancoCog, UrlHandler, get_cog_def
+from cogs.lancocog import LancoCog, UrlHandler
 from db import BaseModel, DatabaseType, database_proxy
 from discord.ext import commands
 from dotenv import load_dotenv
 from logtail import LogtailHandler
 from peewee import *
 from utils.command_utils import is_bot_owner
-from utils.dist_utils import get_bot_version, get_commit_hash
-from utils.network_utils import get_external_ip
 from watchfiles import Change, awatch
 
 DATA_DIR = "data"
@@ -213,6 +209,27 @@ class BlacklistedUser(BaseModel):
 database.create_tables([BlacklistedUser])
 
 
+class CogStatus(Enum):
+    LOADED = auto()
+    RELOADED = auto()
+    UNLOADED = auto()
+    ERROR = auto()
+
+
+@dataclass
+class CogLoadResult:
+    name: str
+    status: CogStatus = CogStatus.ERROR
+    error: Optional[str] = None
+
+
+def _purge_cog_modules(dotted: str):
+    """Remove a cog package and all its submodules from sys.modules so they reload cleanly."""
+    to_remove = [k for k in sys.modules if k == dotted or k.startswith(dotted + ".")]
+    for key in to_remove:
+        del sys.modules[key]
+
+
 class LancoBot(commands.Bot):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -240,34 +257,70 @@ class LancoBot(commands.Bot):
         return DEFAULT_PREFIX
 
     def get_lanco_cog(self, cog_name: str) -> LancoCog:
-        """Returns a LancoCog instance by name."""
         return self.get_cog(cog_name)
 
-    def get_lanco_cog_by_class_name(self, class_name: str) -> LancoCog:
-        for c in self.get_lanco_cogs():
-            if c.get_class_name().lower() == class_name.lower():
-                return c
-        return None
-
-    def get_lanco_cog_by_dotted_path(self, dotted_path: str) -> LancoCog:
-        for c in self.get_lanco_cogs():
-            if c.get_dotted_path() == dotted_path:
-                return c
-        return None
-
     def get_lanco_cogs(self, sort_by_name=True) -> list[LancoCog]:
-        """Get all cogs that are instances of LancoCog"""
         cogs = [c for c in self.cogs.values() if isinstance(c, LancoCog)]
         if sort_by_name:
             return sorted(cogs, key=lambda c: c.get_cog_name())
         return cogs
 
-    def is_cog_loaded(self, qualified_name: str) -> bool:
-        """Check if a cog with the given name is loaded"""
-        for c in self.get_lanco_cogs():
-            if c.get_dotted_path().lower() == qualified_name.lower():
-                return True
-        return False
+    def is_cog_loaded(self, name: str) -> bool:
+        return f"cogs.{name}" in self.extensions
+
+    async def load_cog(self, name: str) -> "CogLoadResult":
+        dotted = f"cogs.{name}"
+        result = CogLoadResult(name)
+        try:
+            if dotted in self.extensions:
+                logger.info(f"Reloading {name}")
+                _purge_cog_modules(dotted)
+                await self.reload_extension(dotted)
+                result.status = CogStatus.RELOADED
+            else:
+                logger.info(f"Loading {name}")
+                await self.load_extension(dotted)
+                result.status = CogStatus.LOADED
+        except Exception as e:
+            logger.error(f"Failed to load cog {name}: {e}")
+            result.status = CogStatus.ERROR
+            result.error = str(e)
+        return result
+
+    async def load_cogs(self) -> list["CogLoadResult"]:
+        cog_whitelist_env = os.getenv("COG_WHITELIST", "")
+        cog_whitelist = (
+            {c.strip().lower() for c in cog_whitelist_env.split(",") if c.strip()}
+            if cog_whitelist_env
+            else None
+        )
+        if cog_whitelist:
+            logger.info(f"COG_WHITELIST active: {cog_whitelist}")
+
+        results = []
+        for entry in os.scandir(COGS_DIR):
+            if not entry.is_dir():
+                continue
+            if cog_whitelist and entry.name.lower() not in cog_whitelist:
+                continue
+            if os.path.isfile(os.path.join(entry.path, "__init__.py")):
+                result = await self.load_cog(entry.name)
+                results.append(result)
+        return results
+
+    async def unload_cog(self, name: str) -> "CogLoadResult":
+        dotted = f"cogs.{name}"
+        result = CogLoadResult(name)
+        if dotted in self.extensions:
+            try:
+                logger.info(f"Unloading {name}")
+                await self.unload_extension(dotted)
+                result.status = CogStatus.UNLOADED
+            except Exception as e:
+                logger.error(f"Failed to unload cog {name}: {e}")
+                result.status = CogStatus.ERROR
+                result.error = str(e)
+        return result
 
     def register_url_handler(self, handler: UrlHandler):
         logger.info(
@@ -299,39 +352,28 @@ class LancoBot(commands.Bot):
     async def on_ready(self):
         logger.info(f"Bot ready: {self.user.name} - {self.user.id}")
 
+    async def setup_hook(self):
+        if self.dev_mode:
+            self.loop.create_task(self._hot_reload_watcher())
+
+    async def _hot_reload_watcher(self):
         async for changes in awatch(COGS_DIR):
-            if not self.dev_mode:
-                continue
-
             reverse_ordered_changes = sorted(changes, reverse=True)
-
-            for change in reverse_ordered_changes:
-                change_type = change[0]
-                change_path = change[1]
-
+            for change_type, change_path in reverse_ordered_changes:
                 path = os.path.normpath(change_path)
                 tokens = path.split(os.sep)
-                reversed_tokens = list(reversed(tokens))
-
-                cog_dir_index = reversed_tokens.index(COGS_DIR.split("/")[0])
-                cog_dir = ".".join([token for token in tokens[-cog_dir_index:-1]])
-                cog_name = cog_dir.split(".")[-1]
-                loaded_cog = self.get_lanco_cog_by_dotted_path(cog_dir)
-
-                cog_def = None
-                if loaded_cog:
-                    cog_def = get_cog_def(loaded_cog.get_cog_name(), COGS_DIR)
-                else:
-                    cog_def = get_cog_def(cog_name, COGS_DIR)
+                try:
+                    cogs_index = tokens.index("cogs")
+                except ValueError:
+                    continue
+                if cogs_index + 1 >= len(tokens):
+                    continue
+                cog_name = tokens[cogs_index + 1]
 
                 if change_type == Change.deleted:
-                    await unload_cog_by_name(self, cog_def.name)
-                elif change_type == Change.added:
-                    await load_cog(self, cog_def)
-                elif change_type == Change.modified and change_type != (
-                    Change.added or Change.deleted
-                ):
-                    await load_cog(self, cog_def)
+                    await self.unload_cog(cog_name)
+                else:
+                    await self.load_cog(cog_name)
 
 
 owner_id = int(os.getenv("OWNER_ID", 0))
@@ -347,18 +389,14 @@ bot = LancoBot(
 @bot.command(name="gsync")
 @commands.is_owner()
 async def guildsync(ctx):
-    """Sync commands for a specific guild"""
     guild = ctx.guild
     embed = discord.Embed(
         title=f"Syncing Guild: {guild.name}",
         description="Wait a moment...",
         color=discord.Color.dark_gray(),
     )
-
     msg = await ctx.send(embed=embed)
-
     logger.info(f"Syncing guild: {guild.name}")
-
     try:
         synced = await bot.tree.sync(guild=guild)
         logger.info(f"Synced {len(synced)} commands for {guild.name}")
@@ -377,9 +415,7 @@ async def sync(ctx):
         description="Wait a moment...",
         color=discord.Color.dark_gray(),
     )
-
     msg = await ctx.send(embed=embed)
-
     logger.info("Syncing commands")
     try:
         synced = await bot.tree.sync()
@@ -391,403 +427,65 @@ async def sync(ctx):
         logger.error(e)
 
 
-@bot.tree.command(name="ping", description="Ping the bot")
-async def ping(interaction: discord.Interaction):
-    lat = round(bot.latency * 1000)
-
-    embed = discord.Embed(title="🏓 Pong!", color=0x00FF00)
-    embed.add_field(name="Bot Latency", value=f"{lat}ms", inline=False)
-
-    start = monotonic()
-    msg = await interaction.response.send_message(embed=embed)
-    end = monotonic()
-
-    response_msg = await interaction.original_response()
-
-    msg_latency = round((end - start) * 1000)
-
-    embed.add_field(name="Message Latency", value=f"{msg_latency}ms", inline=False)
-    await response_msg.edit(embed=embed)
+@bot.tree.command(name="reload", description="Reload a cog")
+@is_bot_owner()
+async def reload_cog(interaction: discord.Interaction, cog_name: str):
+    result = await bot.load_cog(cog_name)
+    embed = discord.Embed(title=f'Reloading Cog: "{cog_name}"', color=0x00FF00)
+    if result.status == CogStatus.LOADED:
+        embed.description = f"Loaded {cog_name}"
+    elif result.status == CogStatus.RELOADED:
+        embed.description = f"Reloaded {cog_name}"
+    elif result.status == CogStatus.ERROR:
+        embed.description = f"Error loading {cog_name}: ```{result.error}```"
+    await interaction.response.send_message(embed=embed)
 
 
-@bot.tree.command(name="dbinfo", description="Show database info")
-@commands.is_owner()
-async def dbinfo(interaction: discord.Interaction):
-    embed = discord.Embed(
-        title="Database Info",
-        color=0x00FF00,
-    )
+@bot.tree.command(name="reloadall", description="Reload all cogs")
+@is_bot_owner()
+async def reload_all(interaction: discord.Interaction):
+    embed = discord.Embed(title="[Re]-Loaded Cogs", color=0x00FF00)
+    results = await bot.load_cogs()
 
-    db_size = 0
-    if db_type == DatabaseType.SQLITE:
-        db_size = os.path.getsize(sqlite_path)
-    elif db_type == DatabaseType.MYSQL:
-        query = """
-        SELECT SUM(data_length + index_length) 
-        FROM information_schema.tables 
-        WHERE table_schema = DATABASE();
-        """
-        cursor = database.execute_sql(query)
-        db_size = cursor.fetchone()[0]  # in bytes
+    reloaded = [r.name for r in results if r.status == CogStatus.RELOADED]
+    loaded = [r.name for r in results if r.status == CogStatus.LOADED]
+    errored = [r.name for r in results if r.status == CogStatus.ERROR]
 
-    embed.add_field(name="Type", value=f"{db_type.name}", inline=False)
-
-    size_in_mb = db_size / 1024 / 1024
-    embed.add_field(name="Size", value=f"{size_in_mb:.2f} MB", inline=False)
-
-    await interaction.response.send_message(embed=embed, ephemeral=True)
-
-
-@bot.tree.command(name="netstats", description="Show network stats")
-async def netstats(interaction: discord.Interaction):
-    is_owner = await bot.is_owner(interaction.user)
-
-    embed = discord.Embed(
-        title="Network Stats",
-        description="Various network stats",
-        color=0x00FF00,
-    )
-
-    ip = await get_external_ip()
-
-    if is_owner:
-        embed.add_field(name="External IP", value=ip, inline=False)
-    else:
-        embed.add_field(name="External IP", value="🔒 Hidden", inline=False)
+    def fmt(names):
+        return f"```{chr(10).join(names)}```" if names else "None"
 
     embed.add_field(
-        name="Latency", value=f"{round(bot.latency * 1000)}ms", inline=False
+        name=f"Reloaded ({len(reloaded)}):", value=fmt(reloaded), inline=False
     )
+    embed.add_field(name=f"Loaded ({len(loaded)}):", value=fmt(loaded), inline=False)
+    error_value = fmt(errored)
+    if errored:
+        error_value += "\nRun the `/reload cog_name` command for more info"
+    embed.add_field(name=f"Failed ({len(errored)}):", value=error_value, inline=False)
+    await interaction.response.send_message(embed=embed)
 
-    await interaction.response.send_message(embed=embed, ephemeral=True)
 
-
-@bot.tree.command(name="info", description="Show bot info")
-async def info(interaction: discord.Interaction):
-    info = await bot.application_info()
-
-    desc = f"{bot.user.name} is a general-purpose Discord bot tailored for Lancaster County, PA Discord servers.\n\n"
-
-    links = {
-        "Homepage": "https://lancobot.dev",
-        "GitHub": "https://github.com/NateShoffner/lanco-discord-bot",
-        "Privacy Policy": "https://lancobot.dev/privacy",
-        "Terms of Service": "https://lancobot.dev/terms",
-    }
-
-    for name, url in links.items():
-        desc += f"[{name}]({url})\n"
-
-    embed = discord.Embed(
-        title=f"{bot.user.name} Info",
-        description=desc,
-        color=0x00FF00,
-    )
-
-    discord_py_version = discord.__version__
-
-    users = len(bot.users)
-    unique_users = 0
-    for g in bot.guilds:
-        unique_users += len(g.members)
-
-    channels = [c for c in bot.get_all_channels()]
-    total_channels = 0
-    text_channels = 0
-    voice_channels = 0
-
-    for channel in channels:
-        total_channels += 1
-        if isinstance(channel, discord.TextChannel):
-            text_channels += 1
-        elif isinstance(channel, discord.VoiceChannel):
-            voice_channels += 1
-
-    guilds = len(bot.guilds)
-    shards = bot.shard_count if bot.shard_count else 1
-
-    commands = len(bot.commands)
-    slash_commands = len(bot.tree.get_commands())
-
-    uptime = datetime.datetime.now() - bot.start_time
-    uptime_str = f"{uptime.days}d {uptime.seconds // 3600}h {(uptime.seconds // 60) % 60}m {uptime.seconds % 60}s"
-
-    message_cache = len(bot.cached_messages)
-    voice_clients = len(bot.voice_clients)
-
-    emojis = len(bot.emojis)
-    application_emojis = await bot.fetch_application_emojis()
-    app_emojis = len(application_emojis)
-
-    stickers = len(bot.stickers)
-    url_handlers = len(bot.url_handlers)
-
-    latency = round(bot.latency * 1000)
-    pid = None
-    memory_usage = "N/A"
-    cpu_usage = "N/A"
-
-    try:
-        pid = os.getpid()
-        process = psutil.Process(pid)
-        memory_usage = f"{process.memory_info().rss / 1024 / 1024:.2f} MB"
-        cpu_usage = f"{psutil.cpu_percent(interval=1)}%"
-    except Exception as e:
-        logger.error(f"Failed to get memory/cpu usage: {e}")
-
-    owner_str = "Unknown"
-    if info.owner:
-        owner_str = f"{info.owner.name}"
-    if info.team:  # TODO get team info
-        owner_str = f"{info.team.name}"
-
-    embed.add_field(name="Servers", value=f"Total: {guilds}\nShards: {shards}")
-    embed.add_field(name="Users", value=f"Total: {users}\nUnique: {unique_users}")
-    embed.add_field(
-        name="Channels",
-        value=f"Total: {total_channels}\nText: {text_channels}\nVoice: {voice_channels}",
-    )
-    embed.add_field(
-        name="Commands", value=f"Normal: {commands}\nSlash: {slash_commands}"
-    )
-    embed.add_field(
-        name="Assets",
-        value=f"Emojis: {emojis}\nApp Emojis: {app_emojis}\nStickers: {stickers}",
-    )
-    embed.add_field(
-        name="Process", value=f"RAM: {memory_usage}\nCPU: {cpu_usage}\nPID: {pid}"
-    )
-    embed.add_field(name="Latency", value=f"{latency}ms")
-    embed.add_field(
-        name="Dev Mode", value=f"{'Enabled' if bot.dev_mode else 'Disabled'}"
-    )
-    embed.add_field(
-        name="Uptime",
-        value=uptime_str,
-    )
-    embed.add_field(name="Cogs", value=f"{len(bot.get_lanco_cogs())}")
-
-    embed.add_field(name="Owner", value=owner_str)
-
-    commit = get_commit_hash()
-    github = os.getenv("GITHUB_REPO")
-    if github:
-        commit_url = f"{github}/commit/{commit}"
-        embed.add_field(
-            name="Version", value=f"v{get_bot_version()} - [{commit[:7]}]({commit_url})"
-        )
-    else:
-        embed.add_field(
-            name="Version", value=f"v{get_bot_version()} - Commit: {commit[:7]}"
-        )
-
-    embed.add_field(name="Message Cache", value=f"{message_cache}")
-    embed.add_field(name="Voice Clients", value=f"{voice_clients}")
-
-    embed.add_field(name="URL Handlers", value=f"{url_handlers}")
-
-    logo_url = "https://lancobot.dev/discord.py.png"
-
-    python_version_str = f"{sysv.major}.{sysv.minor}.{sysv.micro}"
-
-    embed.set_footer(
-        text=f"Made with ❤️ with Discord.py v{discord_py_version} on Python {python_version_str}",
-        icon_url=logo_url,
-    ),
-
+@bot.tree.command(name="unload", description="Unload a cog")
+@is_bot_owner()
+async def unload_cog(interaction: discord.Interaction, cog_name: str):
+    result = await bot.unload_cog(cog_name)
+    embed = discord.Embed(title=f"Unloading Cog: {cog_name}", color=0x00FF00)
+    if result.status == CogStatus.UNLOADED:
+        embed.description = f"Unloaded {cog_name}"
+    elif result.status == CogStatus.ERROR:
+        embed.description = f"Error unloading {cog_name}: ```{result.error}```"
     await interaction.response.send_message(embed=embed)
 
 
 @bot.tree.command(name="devmode")
 @is_bot_owner()
-async def dev(interaction: discord.Interaction):
+async def devmode(interaction: discord.Interaction):
     bot.set_dev_mode(not bot.dev_mode)
-
     embed = discord.Embed(
         title="Dev Mode",
-        description=f"{'Enabled' if bot.dev_mode else 'Disabled'}",
+        description="Enabled" if bot.dev_mode else "Disabled",
         color=0x00FF00,
     )
-
-    await interaction.response.send_message(embed=embed)
-
-
-@bot.tree.command(name="cogs", description="List loaded cogs")
-async def cogs(interaction: discord.Interaction):
-    cogs = bot.get_lanco_cogs()
-    cog_list = ""
-    for cog in cogs:
-        cog_list += f"{cog.qualified_name} - {cog.description}\n"
-    embed = discord.Embed(
-        title=f"Loaded Cogs: {len(cogs)}",
-        description=f"```{cog_list}```",
-        color=0x00FF00,
-    )
-
-    await interaction.response.send_message(embed=embed)
-
-
-@bot.tree.command(name="reload", description="Reload a cog")
-@is_bot_owner()
-async def reload_cog(interaction: discord.Interaction, cog_name: str):
-    """Reload a single cog."""
-
-    cog_def = get_cog_def(cog_name, COGS_DIR)
-    result = await load_cog(bot, cog_def)
-
-    embed = discord.Embed(
-        title=f'Reloading Cog: "{cog_def.name}"',
-        color=0x00FF00,
-    )
-
-    if result.loaded:
-        embed.description = f"Loaded {cog_def.name}"
-    elif result.reloaded:
-        embed.description = f"Reloaded {cog_def.name}"
-    elif result.error:
-        embed.description = f"Error loading {cog_def.name}: ```{result.error}```"
-
-    await interaction.response.send_message(embed=embed)
-
-
-@dataclass
-class CogLoadResult:
-    definition: CogDefinition
-    loaded: bool = False
-    reloaded: bool = False
-    unloaded: bool = False
-    error: Optional[str] = None
-    cog: Optional[LancoCog] = None
-
-
-async def load_cog(bot: LancoBot, cog_def: CogDefinition) -> CogLoadResult:
-    """Load a single cog."""
-    is_already_loaded = bot.is_cog_loaded(cog_def.qualified_name)
-    result = CogLoadResult(cog_def)
-
-    try:
-        if is_already_loaded:
-            logger.info(f"Reloading {cog_def.name}: {cog_def.path}")
-
-            await bot.reload_extension(cog_def.qualified_name)
-        else:
-            logger.info(f"Loading {cog_def.name}: {cog_def.path}")
-            await bot.load_extension(cog_def.qualified_name)
-        result.loaded = True
-        result.cog = bot.get_lanco_cog_by_dotted_path(cog_def.qualified_name)
-        result.cog.set_cog_def(cog_def)
-
-    except Exception as e:
-        logger.error(f"Failed to load cog {cog_def.name}: {e}")
-        result.error = str(e)
-
-    return result
-
-
-async def load_cogs(bot: LancoBot) -> list[CogLoadResult]:
-    """Load all cogs in the cogs directory."""
-    cog_whitelist_env = os.getenv("COG_WHITELIST", "")
-    cog_whitelist = (
-        {c.strip().lower() for c in cog_whitelist_env.split(",") if c.strip()}
-        if cog_whitelist_env
-        else None
-    )
-    if cog_whitelist:
-        logger.info(f"COG_WHITELIST active: {cog_whitelist}")
-
-    results = []
-    for entry in os.scandir(COGS_DIR):
-        cog_def = get_cog_def(entry.name, COGS_DIR)
-        if cog_whitelist and entry.name.lower() not in cog_whitelist:
-            continue
-        if os.path.isfile(cog_def.entry_point):
-            result = await load_cog(bot, cog_def)
-            results.append(result)
-    return results
-
-
-async def unload_cog_by_name(bot: LancoBot, cog_name: str) -> CogLoadResult:
-    """Unload a single cog."""
-    cog = bot.get_lanco_cog(cog_name)
-    cog_def = get_cog_def(cog_name, COGS_DIR)
-
-    result = CogLoadResult(cog_def)
-    cog = bot.get_lanco_cog_by_class_name(cog_name)
-    if cog:
-        try:
-            logger.info(f"Unloading {cog_name}")
-            await bot.unload_extension(f"cogs.{cog_name}.{cog_name}")
-            result.unloaded = True
-        except Exception as e:
-            logger.error(f"Failed to unload cog {cog_name}: {e}")
-            result.error = str(e)
-
-    return result
-
-
-@bot.tree.command(name="reloadall")
-@is_bot_owner()
-async def reload_all(interaction: discord.Interaction):
-    """This commands reloads all the cogs in the `./cogs` folder."""
-
-    embed = discord.Embed(
-        title=f"[Re]-Loaded Cogs",
-        color=0x00FF00,
-    )
-
-    results = await load_cogs(bot)
-
-    reloaded_cogs = [result.cog.get_cog_name() for result in results if result.reloaded]
-    loaded_cogs = [result.cog.get_cog_name() for result in results if result.loaded]
-    errored_cogs = [result.definition.entry_point for result in results if result.error]
-
-    reload_value = "None"
-    if len(reloaded_cogs) > 0:
-        reload_value = "```"
-        reload_value += "\n".join(reloaded_cogs)
-        reload_value += "```"
-    embed.add_field(
-        name=f"Reloaded ({len(reloaded_cogs)}):", value=reload_value, inline=False
-    )
-
-    load_value = "None"
-    if len(loaded_cogs) > 0:
-        load_value = "```"
-        load_value += "\n".join(loaded_cogs)
-        load_value += "```"
-    embed.add_field(
-        name=f"Loaded ({len(loaded_cogs)}):", value=load_value, inline=False
-    )
-
-    error_value = "None"
-    if len(errored_cogs) > 0:
-        error_value = "```"
-        error_value += "\n".join(errored_cogs)
-        error_value += "```"
-        error_value += "\nRun the `/reload cog_name` command for more info"
-    embed.add_field(
-        name=f"Failed ({len(errored_cogs)}):", value=error_value, inline=False
-    )
-
-    await interaction.response.send_message(embed=embed)
-
-
-@bot.tree.command(name="unload")
-@is_bot_owner()
-async def unload_cog(interaction: discord.Interaction, cog_name: str):
-    """Unload a single cog."""
-    result = await unload_cog_by_name(bot, cog_name)
-
-    embed = discord.Embed(
-        title=f"Unloading Cog: {cog_name}",
-        color=0x00FF00,
-    )
-
-    if result.unloaded:
-        embed.description = f"Unloaded {cog_name}"
-    elif result.error:
-        embed.description = f"Error unloading {cog_name}: ```{result.error}```"
-
     await interaction.response.send_message(embed=embed)
 
 
@@ -795,61 +493,7 @@ async def unload_cog(interaction: discord.Interaction, cog_name: str):
 async def global_block_check(ctx):
     if BlacklistedUser.get_or_none(user_id=ctx.author.id):
         return False
-
     return True
-
-
-@bot.tree.command(name="optout")
-async def optout(interaction: discord.Interaction):
-    """Opt out of the bot."""
-    user = interaction.user
-    BlacklistedUser.create(user_id=user.id)
-    await interaction.response.send_message(
-        "You have opted out of the bot.", ephemeral=True
-    )
-
-
-@bot.tree.command(name="optin")
-async def optin(interaction: discord.Interaction):
-    """Opt in to the bot."""
-    user = interaction.user
-    u = BlacklistedUser.get_or_none(user_id=user.id)
-
-    if not u:
-        await interaction.response.send_message(
-            "You are already opted in to the bot.", ephemeral=True
-        )
-        return
-
-    u.delete_instance()
-    await interaction.response.send_message(
-        "You have opted in to the bot.", ephemeral=True
-    )
-
-
-@bot.tree.command(name="block")
-@commands.is_owner()
-async def block(interaction: discord.Interaction, user: discord.User, reason: str):
-    """Block a user"""
-    BlacklistedUser.create(user_id=user.id, reason=reason)
-    await interaction.response.send_message(
-        f"Blocked {user.mention} for {reason}", ephemeral=True
-    )
-
-
-@bot.tree.command(name="unblock")
-@commands.is_owner()
-async def unblock(interaction: discord.Interaction, user: discord.User):
-    """Unblock a user"""
-    u = BlacklistedUser.get_or_none(user_id=user.id)
-    if not u:
-        await interaction.response.send_message(
-            f"{user.mention} is not blocked", ephemeral=True
-        )
-        return
-
-    u.delete_instance()
-    await interaction.response.send_message(f"Unblocked {user.mention}", ephemeral=True)
 
 
 async def main():
@@ -862,7 +506,7 @@ async def main():
             _prefix_cache[config.guild_id] = config.prefix
 
     db_backup = DatabaseBackup()
-    await load_cogs(bot)
+    await bot.load_cogs()
     async with bot:
         db_backup.start()
         await bot.start(os.getenv("DISCORD_TOKEN"))

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -81,8 +81,7 @@ async def test_all_cogs_load_without_errors(bot):
     environment and are treated as warnings, not failures. Any other error
     (import errors, syntax errors, etc.) is a hard failure.
     """
-    from cogs.lancocog import get_cog_def
-    from main import load_cog
+    from main import CogStatus
 
     # Errors that are acceptable in a test environment (missing keys, missing
     # system libraries that are present in Docker, optional uninstalled deps)
@@ -114,21 +113,20 @@ async def test_all_cogs_load_without_errors(bot):
     skipped = []
 
     for entry in os.scandir(COGS_DIR):
-        if entry.name.startswith("__") or entry.name.endswith(".py"):
+        if not entry.is_dir():
             continue
-        cog_def = get_cog_def(entry.name, "app/cogs")
-        if not os.path.isfile(cog_def.entry_point):
+        if not os.path.isfile(os.path.join(entry.path, "__init__.py")):
             continue
-        result = await load_cog(bot, cog_def)
-        if result.error:
+        result = await bot.load_cog(entry.name)
+        if result.status == CogStatus.ERROR:
             if any(
                 phrase in result.error for phrase in expected_missing_config_phrases
             ):
                 skipped.append(
-                    f"{cog_def.name}: missing API config (expected in test env)"
+                    f"{entry.name}: missing API config (expected in test env)"
                 )
             else:
-                hard_failures.append(f"{cog_def.name}: {result.error}")
+                hard_failures.append(f"{entry.name}: {result.error}")
 
     if skipped:
         print(f"\nSkipped {len(skipped)} cogs due to missing API config:")
@@ -142,35 +140,26 @@ async def test_all_cogs_load_without_errors(bot):
 
 async def test_loaded_cogs_are_discoverable(bot):
     """After loading a cog, it should appear in get_lanco_cogs()."""
-    from cogs.lancocog import get_cog_def
-    from main import load_cog
+    from main import CogStatus
 
-    cog_def = get_cog_def("bot", "app/cogs")
-    result = await load_cog(bot, cog_def)
+    result = await bot.load_cog("bot")
 
-    assert result.loaded
+    assert result.status == CogStatus.LOADED
     assert result.error is None
     assert any(c.get_cog_name().lower() == "bot" for c in bot.get_lanco_cogs())
 
 
 async def test_is_cog_loaded_reflects_state(bot):
     """is_cog_loaded() should return False before loading and True after."""
-    from cogs.lancocog import get_cog_def
-    from main import load_cog
+    assert not bot.is_cog_loaded("bot")
 
-    cog_def = get_cog_def("bot", "app/cogs")
-    assert not bot.is_cog_loaded(cog_def.qualified_name)
-
-    await load_cog(bot, cog_def)
-    assert bot.is_cog_loaded(cog_def.qualified_name)
+    await bot.load_cog("bot")
+    assert bot.is_cog_loaded("bot")
 
 
 def test_missing_cog_entry_point_is_skipped():
-    """A stub cog directory with no entry point file should have no loadable file."""
-    from cogs.lancocog import get_cog_def
-
-    cog_def = get_cog_def("csvtable", "app/cogs")
-    assert not os.path.isfile(cog_def.entry_point)
+    """A cog directory without __init__.py should not be loadable."""
+    assert not os.path.isfile(os.path.join(COGS_DIR, "csvtable", "__init__.py"))
 
 
 # ---------------------------------------------------------------------------
@@ -180,15 +169,10 @@ def test_missing_cog_entry_point_is_skipped():
 
 async def test_register_url_handler(bot):
     """Registering a URL handler should make it retrievable."""
-    from cogs.lancocog import get_cog_def
-    from main import load_cog
-
-    # Load a real cog to use as the handler's cog reference
-    cog_def = get_cog_def("bot", "app/cogs")
-    result = await load_cog(bot, cog_def)
-    cog = result.cog
-
     from cogs.lancocog import UrlHandler
+
+    await bot.load_cog("bot")
+    cog = bot.get_lanco_cog("Bot")
 
     handler = UrlHandler(
         url_pattern=re.compile(r"https://example\.com/.*"),
@@ -203,12 +187,10 @@ async def test_register_url_handler(bot):
 
 async def test_get_url_handler_returns_correct_handler(bot):
     """get_url_handler() should return the matching handler."""
-    from cogs.lancocog import UrlHandler, get_cog_def
-    from main import load_cog
+    from cogs.lancocog import UrlHandler
 
-    cog_def = get_cog_def("bot", "app/cogs")
-    result = await load_cog(bot, cog_def)
-    cog = result.cog
+    await bot.load_cog("bot")
+    cog = bot.get_lanco_cog("Bot")
 
     handler = UrlHandler(
         url_pattern=re.compile(r"https://spotify\.com/.*"),

--- a/tools/cog.py
+++ b/tools/cog.py
@@ -161,77 +161,9 @@ def cmd_report(args: argparse.Namespace) -> int:
     return 0
 
 
-COG_BLACKLIST = [
-    "LancoCog",
-    "Demo",
-    "JeffVacation",
-    "ChatRelay",
-]
-
-
-def cmd_generate(args: argparse.Namespace) -> int:
-    """
-    Generate a markdown table of all cogs with links and descriptions, skipping blacklisted cogs.
-    Output is formatted as a grid of 3 columns per row, each cell containing a link and description.
-    """
-    # Adjust these as needed for your repo
-    GITHUB_BASE = (
-        "https://github.com/NateShoffner/lanco-discord-bot/tree/master/app/cogs"
-    )
-
-    cogs = []
-    for root, _, files in os.walk(COG_DIR):
-        for f in files:
-            if not f.endswith(".py"):
-                continue
-            full_path = os.path.join(root, f)
-            try:
-                class_node = _find_cog_class(full_path)
-                if class_node and isinstance(class_node, ast.ClassDef):
-                    name, description = _extract_cog_metadata(class_node)
-                    if not name:
-                        name = os.path.splitext(f)[0]
-                    if name in COG_BLACKLIST:
-                        continue
-                    if not description:
-                        description = "No description"
-                    rel_dir = os.path.relpath(root, COG_DIR)
-                    url = f"{GITHUB_BASE}/{rel_dir}"
-                    link = f"[{name}]({url})"
-                    cell = f"{link}<br>{description}"
-                    cogs.append(cell)
-            except Exception:
-                continue
-
-    # Format as a 3-column grid
-    COLS = 3
-    rows = []
-    for i in range(0, len(cogs), COLS):
-        row = cogs[i : i + COLS]
-        # Pad row to COLS columns
-        while len(row) < COLS:
-            row.append("")
-        rows.append(row)
-
-    if rows:
-        output_lines = ["| " + " | ".join([""] * COLS) + " |"]
-        output_lines.append("|" + "|".join("---" for _ in range(COLS)) + "|")
-        for row in rows:
-            output_lines.append("| " + " | ".join(row) + " |")
-    else:
-        output_lines = ["No cogs found."]
-
-    output_str = "\n".join(output_lines)
-    output_file = getattr(args, "output", None) or "COGS.md"
-    with open(output_file, "w", encoding="utf-8") as f:
-        f.write(output_str + "\n")
-    print(f"✅ Markdown table written to {output_file}")
-    return 0
-
-
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        prog="cog", description="Manage project cogs (create, delete, report, generate)"
+        prog="cog", description="Manage project cogs (create, delete, report)"
     )
     sub = parser.add_subparsers(dest="command", required=True)
 
@@ -248,9 +180,6 @@ def build_parser() -> argparse.ArgumentParser:
 
     p_report = sub.add_parser("report", help="Report cog names & descriptions")
     p_report.set_defaults(func=cmd_report)
-
-    p_generate = sub.add_parser("generate", help="Generate markdown table of cogs")
-    p_generate.set_defaults(func=cmd_generate)
 
     return parser
 

--- a/tools/cog.py
+++ b/tools/cog.py
@@ -49,6 +49,12 @@ def cmd_create(args: argparse.Namespace) -> int:
 
     print(f"✅ Cog '{name}' created at {file_path}")
 
+    init_file_path = os.path.join(dir_path, "__init__.py")
+    with open(init_file_path, "w", encoding="utf-8") as f:
+        f.write(f"from .{name.lower()} import setup\n")
+
+    print(f"✅ __init__.py created at {init_file_path}")
+
     with open(readme_path, "r", encoding="utf-8") as f:
         readme_template = f.read()
 

--- a/tools/templates/cog_template.py
+++ b/tools/templates/cog_template.py
@@ -1,26 +1,13 @@
-"""
-COGNAME Cog
-
-Description:
-COGDESCRIPTION
-"""
-
 from cogs.lancocog import LancoCog
 from discord.ext import commands
 
 
-class COGNAME(
-    LancoCog,
-    name="COGNAME",
-    description="COGDESCRIPTION",
-):
+class COGNAME(LancoCog, name="COGNAME", description="COGDESCRIPTION"):
     def __init__(self, bot):
         super().__init__(bot)
 
-    @commands.command()
-    async def hello(self, ctx):
-        """Responds with a hello message."""
-        await ctx.send("Hello from COGNAME!")
+    async def cog_load(self):
+        await super().cog_load()
 
 
 async def setup(bot):

--- a/tools/templates/readme_template.md
+++ b/tools/templates/readme_template.md
@@ -1,3 +1,9 @@
-# COGNAME Cog
+# COGNAME
 
 COGDESCRIPTION
+
+## Commands
+
+| Command | Description |
+|---|---|
+| `/command` | Description |


### PR DESCRIPTION
## Cog system overhaul + documentation

Closes #72
Closes #21

### What changed

Switched from ad-hoc cog loading to a proper Python package-based approach, cleaned up dead abstractions, and documented every cog.

---

### Cog loading

**Before:** `main.py` scanned for `<dir>/<dir>.py` files and imported them directly by file path. Each cog had to register a `CogDefinition` dataclass and call `set_cog_def()` in `setup()`. Loaded state was tracked in a separate dict alongside `bot.extensions`.

**After:** Each cog directory is a Python package with an `__init__.py` that re-exports `setup()`. Loading goes through `load_extension("cogs.<name>")` and `bot.extensions` is the only source of truth.

#### Load flow

```
Before
------
main.py
  └─ os.scandir(cogs/)
       └─ match <dir>/<dir>.py
            └─ importlib.util.spec_from_file_location()
                 └─ CogDefinition.set_cog_def()   <- manual registration
                      └─ bot.load_extension(path)
                           └─ loaded_cogs dict     <- parallel state

After
-----
main.py / LancoBot.load_cogs()
  └─ os.scandir(cogs/)
       └─ require __init__.py present
            └─ bot.load_extension("cogs.<name>")
                 └─ bot.extensions                 <- single source of truth
```

#### Reload flow

```
Before
------
/reload <name>
  └─ bot.reload_extension(path)
       └─ only top-level .py reloaded
            └─ models.py / submodules: stale (cached in sys.modules)

After
-----
/reload <name>
  └─ _purge_cog_modules("cogs.<name>")   <- removes all cogs.<name>.* from sys.modules
       └─ bot.reload_extension("cogs.<name>")
            └─ full reimport of package + all submodules
```

#### Hot-reload watcher

```
Before                          After
------                          -----
on_ready()                      setup_hook()
  └─ asyncio.ensure_future()      └─ loop.create_task()
       └─ awatch(cogs/)                └─ awatch(cogs/)
            └─ match exact .py              └─ map any file change
                                                 to cog package dir
                                                      └─ load_cog() / unload_cog()
```

---

### Dead code removed

| Removed | Replaced with |
|---|---|
| `CogDefinition` dataclass | (nothing) |
| `get_cog_def()` / `set_cog_def()` | (nothing) |
| `get_lanco_cog_by_class_name()` | (nothing) |
| `get_lanco_cog_by_dotted_path()` | (nothing) |
| `loaded_cogs` dict | `bot.extensions` |
| `LancoCog.on_ready` listener | `LancoCog.cog_load()` |
| bool pair `loaded`/`reloaded` | `CogStatus` enum |

---

### New structure

- `CogStatus` enum: `LOADED`, `RELOADED`, `UNLOADED`, `ERROR`
- `CogLoadResult` dataclass: name, status, optional error string
- `LancoBot.load_cog()` / `unload_cog()` / `load_cogs()`: cog lifecycle lives on the bot class now
- `app/cogs/system/`: new cog for `/ping`, `/info`, `/cogs`, `/netstats`, `/dbinfo`, `/block`, `/unblock`
- `app/cogs/user/`: new cog for `/optout`, `/optin`
- Bootstrap commands (`/reload`, `/reloadall`, `/unload`, `/devmode`, `.sync`, `.gsync`) stay in `main.py`

---

### Cog fixes

- `adhdchannel` and `incidents`: moved task loop start from `on_ready` to `cog_load()`, which broke when `LancoCog.on_ready` was removed

---

### Documentation

- Added `README.md` to every cog that was missing one (34 cogs) using `geoguesser/README.md` as the template
- Replaced the 3-column cog grid in the project `README.md` with a flat alphabetical list
- Updated `CLAUDE.md` to reflect the new package structure and remove `CogDefinition` references

---

### Tooling

- `poetry run cog create` now generates `__init__.py` alongside the cog file; previously the scaffolded cog would silently fail to load
- Removed `poetry run cog generate`; the README table it produced is now maintained manually
- Updated `cog_template.py` and `readme_template.md` to match current conventions
