### PR TITLE
feat(facebookembed): add Facebook embed fix cog

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,82 +6,83 @@ General-purpose Discord bot with some tailored features for Lancaster County, PA
 
 The bot is built around a modular cog system. Each cog is self-contained and can be enabled or disabled independently.
 
-- [ADHDChannel](app/cogs/adhdchannel) — Dynamic channel topic updates
-- [AIDetection](app/cogs/AIDetection) — Detect AI-generated content
-- [Admin](app/cogs/admin) — Admin commands
-- [Anime](app/cogs/anime) — Anime info lookup
-- [AnimeToday](app/cogs/animetoday) — Daily anime announcements
-- [Astrology](app/cogs/astrology) — Horoscope readings
-- [AutoReact](app/cogs/autoreact) — Keyword auto-reactions
-- [AutoResponse](app/cogs/autoresponse) — Keyword auto-responses
-- [BarHopper](app/cogs/barhopper) — Bar hopper commands
-- [Birthday](app/cogs/birthday) — Birthday announcements
-- [Bot](app/cogs/bot) — Bot configuration
-- [ChatBot](app/cogs/chatbot) — AI chatbot with per-user memory
-- [ChatRelay](app/cogs/chatrelay) — Cross-server message relay
-- [CoinFlip](app/cogs/CoinFlip) — Flip a coin
-- [Commands](app/cogs/commands) — Custom guild commands
-- [Conversions](app/cogs/conversions) — Unit conversions
-- [Counter](app/cogs/counter) — Counting channel game
-- [DadJoke](app/cogs/dadjoke) — Dad jokes
-- [DatabaseBackupper](app/cogs/databasebackupper) — Scheduled DB backups
-- [Describe](app/cogs/describe) — Describe images via context menu
-- [EmoteTools](app/cogs/emotetools) — Emote and sticker tools
-- [Everbridge](app/cogs/everbridge) — Everbridge alerts
-- [Facts](app/cogs/facts) — Random facts
-- [FileFixer](app/cogs/filefixer) — Convert unsupported file types
-- [Fishbowl](app/cogs/fishbowl) — Auto-expiring message channels
-- [FixIt](app/cogs/fixit) — SeeClickFix issue feed
-- [FortuneCookie](app/cogs/fortunecookie) — Fortune cookies
-- [Fun](app/cogs/fun) — Fun commands
-- [GameStats](app/cogs/gamestats) — Server game statistics
-- [GeoGuesser](app/cogs/geoguesser) — Lancaster-themed GeoGuesser
-- [Genshin](app/cogs/genshin) — Genshin Impact commands
-- [Google](app/cogs/google) — Google search links
-- [HotDog](app/cogs/hotdog) — Profile glizzies
-- [Incidents](app/cogs/incidents) — LCWC incident feed
-- [InstaEmbed](app/cogs/instaembed) — Instagram embed fix
-- [Magic8Ball](app/cogs/magic8ball) — Magic 8 Ball
-- [MarkSafe](app/cogs/marksafe) — Mark yourself safe/unsafe
-- [NewsHeadlines](app/cogs/newsheadlines) — News headlines
-- [NutCheck](app/cogs/nutcheck) — No Nut November tracker
-- [OneWordStory](app/cogs/onewordstory) — Collaborative one-word story
-- [OpenAIPrompts](app/cogs/aiprompts) — AI-powered prompts
-- [PaywallBypass](app/cogs/paywallbypass) — Bypass Lancaster Online paywall
-- [PDFPreview](app/cogs/pdfpreview) — PDF preview generation
-- [PeeCheck](app/cogs/peecheck) — Hydration tracker
-- [PetTax](app/cogs/pettax) — Pet tax enforcement
-- [Pinboard](app/cogs/pinboard) — Personal message pinboard
-- [Profile](app/cogs/profile) — Custom user profiles
-- [RandomNSFWReddit](app/cogs/randomnsfwreddit) — Random NSFW subreddits
-- [ReactTrack](app/cogs/reacttrack) — Reaction analytics
-- [RedditEmbed](app/cogs/redditembed) — Reddit embed fix
-- [RedditFeed](app/cogs/redditfeed) — Subreddit feed polling
-- [RemindMe](app/cogs/remindme) — Set reminders
-- [RoleStats](app/cogs/rolestats) — Server role statistics
-- [RSSFeed](app/cogs/rssfeed) — RSS feed polling
-- [ScheduledPost](app/cogs/ScheduledPost) — Schedule recurring posts
-- [SleepCheck](app/cogs/sleepcheck) — Sleep hour leaderboard
-- [SpotifyDaylist](app/cogs/spotifydaylist) — Spotify daylist tracking
-- [SpotifyEmbed](app/cogs/spotifyembed) — Spotify embed fix
-- [SpyDotPet](app/cogs/spydotpet) — Detect suspicious bots
-- [Summarize](app/cogs/summarize) — Channel topic and vibe summaries
-- [System](app/cogs/system) — Bot status and admin info
-- [TextGen](app/cogs/textgen) — Text effects (zalgo, etc.)
-- [TikTokEmbed](app/cogs/tiktokembed) — TikTok embed fix
-- [TipCalc](app/cogs/tipcalc) — Tip calculator
-- [TraceMoe](app/cogs/tracemoe) — Identify anime from screenshots
-- [Transcribe](app/cogs/transcribe) — Transcribe audio files
-- [TruthSocial](app/cogs/TruthSocial) — TruthSocial embed support
-- [Twitter/X Embed](app/cogs/twitterembed) — Twitter/X embed fix
-- [User](app/cogs/user) — User opt-in/opt-out
-- [Verification](app/cogs/verification) — Vote-based member verification
-- [Weather](app/cogs/weather) — Weather lookup
-- [WebPreview](app/cogs/webpreview) — Web link previews
-- [WebServer](app/cogs/webserver) — Embedded status web server
-- [Whisper](app/cogs/whisper) — Send private messages
-- [WolframAlpha](app/cogs/wolframalpha) — Wolfram Alpha queries
-- [YouTube](app/cogs/youtube) — YouTube channel feed polling
+- [ADHDChannel](app/cogs/adhdchannel) - Dynamic channel topic updates
+- [AIDetection](app/cogs/AIDetection) - Detect AI-generated content
+- [Admin](app/cogs/admin) - Admin commands
+- [Anime](app/cogs/anime) - Anime info lookup
+- [AnimeToday](app/cogs/animetoday) - Daily anime announcements
+- [Astrology](app/cogs/astrology) - Horoscope readings
+- [AutoReact](app/cogs/autoreact) - Keyword auto-reactions
+- [AutoResponse](app/cogs/autoresponse) - Keyword auto-responses
+- [BarHopper](app/cogs/barhopper) - Bar hopper commands
+- [Birthday](app/cogs/birthday) - Birthday announcements
+- [Bot](app/cogs/bot) - Bot configuration
+- [ChatBot](app/cogs/chatbot) - AI chatbot with per-user memory
+- [ChatRelay](app/cogs/chatrelay) - Cross-server message relay
+- [CoinFlip](app/cogs/CoinFlip) - Flip a coin
+- [Commands](app/cogs/commands) - Custom guild commands
+- [Conversions](app/cogs/conversions) - Unit conversions
+- [Counter](app/cogs/counter) - Counting channel game
+- [DadJoke](app/cogs/dadjoke) - Dad jokes
+- [DatabaseBackupper](app/cogs/databasebackupper) - Scheduled DB backups
+- [Describe](app/cogs/describe) - Describe images via context menu
+- [EmoteTools](app/cogs/emotetools) - Emote and sticker tools
+- [Everbridge](app/cogs/everbridge) - Everbridge alerts
+- [FacebookEmbed](app/cogs/facebookembed) - Facebook embed fix (posts, events, pages, reels)
+- [Facts](app/cogs/facts) - Random facts
+- [FileFixer](app/cogs/filefixer) - Convert unsupported file types
+- [Fishbowl](app/cogs/fishbowl) - Auto-expiring message channels
+- [FixIt](app/cogs/fixit) - SeeClickFix issue feed
+- [FortuneCookie](app/cogs/fortunecookie) - Fortune cookies
+- [Fun](app/cogs/fun) - Fun commands
+- [GameStats](app/cogs/gamestats) - Server game statistics
+- [GeoGuesser](app/cogs/geoguesser) - Lancaster-themed GeoGuesser
+- [Genshin](app/cogs/genshin) - Genshin Impact commands
+- [Google](app/cogs/google) - Google search links
+- [HotDog](app/cogs/hotdog) - Profile glizzies
+- [Incidents](app/cogs/incidents) - LCWC incident feed
+- [InstaEmbed](app/cogs/instaembed) - Instagram embed fix
+- [Magic8Ball](app/cogs/magic8ball) - Magic 8 Ball
+- [MarkSafe](app/cogs/marksafe) - Mark yourself safe/unsafe
+- [NewsHeadlines](app/cogs/newsheadlines) - News headlines
+- [NutCheck](app/cogs/nutcheck) - No Nut November tracker
+- [OneWordStory](app/cogs/onewordstory) - Collaborative one-word story
+- [OpenAIPrompts](app/cogs/aiprompts) - AI-powered prompts
+- [PaywallBypass](app/cogs/paywallbypass) - Bypass Lancaster Online paywall
+- [PDFPreview](app/cogs/pdfpreview) - PDF preview generation
+- [PeeCheck](app/cogs/peecheck) - Hydration tracker
+- [PetTax](app/cogs/pettax) - Pet tax enforcement
+- [Pinboard](app/cogs/pinboard) - Personal message pinboard
+- [Profile](app/cogs/profile) - Custom user profiles
+- [RandomNSFWReddit](app/cogs/randomnsfwreddit) - Random NSFW subreddits
+- [ReactTrack](app/cogs/reacttrack) - Reaction analytics
+- [RedditEmbed](app/cogs/redditembed) - Reddit embed fix
+- [RedditFeed](app/cogs/redditfeed) - Subreddit feed polling
+- [RemindMe](app/cogs/remindme) - Set reminders
+- [RoleStats](app/cogs/rolestats) - Server role statistics
+- [RSSFeed](app/cogs/rssfeed) - RSS feed polling
+- [ScheduledPost](app/cogs/ScheduledPost) - Schedule recurring posts
+- [SleepCheck](app/cogs/sleepcheck) - Sleep hour leaderboard
+- [SpotifyDaylist](app/cogs/spotifydaylist) - Spotify daylist tracking
+- [SpotifyEmbed](app/cogs/spotifyembed) - Spotify embed fix
+- [SpyDotPet](app/cogs/spydotpet) - Detect suspicious bots
+- [Summarize](app/cogs/summarize) - Channel topic and vibe summaries
+- [System](app/cogs/system) - Bot status and admin info
+- [TextGen](app/cogs/textgen) - Text effects (zalgo, etc.)
+- [TikTokEmbed](app/cogs/tiktokembed) - TikTok embed fix
+- [TipCalc](app/cogs/tipcalc) - Tip calculator
+- [TraceMoe](app/cogs/tracemoe) - Identify anime from screenshots
+- [Transcribe](app/cogs/transcribe) - Transcribe audio files
+- [TruthSocial](app/cogs/TruthSocial) - TruthSocial embed support
+- [Twitter/X Embed](app/cogs/twitterembed) - Twitter/X embed fix
+- [User](app/cogs/user) - User opt-in/opt-out
+- [Verification](app/cogs/verification) - Vote-based member verification
+- [Weather](app/cogs/weather) - Weather lookup
+- [WebPreview](app/cogs/webpreview) - Web link previews
+- [WebServer](app/cogs/webserver) - Embedded status web server
+- [Whisper](app/cogs/whisper) - Send private messages
+- [WolframAlpha](app/cogs/wolframalpha) - Wolfram Alpha queries
+- [YouTube](app/cogs/youtube) - YouTube channel feed polling
 
 ## 🚀 Installation
 
@@ -128,7 +129,7 @@ Join the [Lancaster County Discord](https://discord.gg/yfFp4VaZFt) or [open an i
 
 ## 📝 License
 
-This project is licensed under the MIT License — see the [LICENSE](LICENSE) file for details.
+This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.
 
 ## 📂 Project Structure
 

--- a/app/cogs/facebookembed/README.md
+++ b/app/cogs/facebookembed/README.md
@@ -1,0 +1,28 @@
+# Facebook Embed Fixer
+
+Replaces broken Facebook embeds with rich previews. URLs are routed by type: reels and videos are rewritten to the [facebed](https://github.com/facebed/facebed) service for playable media, while posts, events, and pages are embedded natively from Facebook's OpenGraph data.
+
+## Commands
+
+| Command | Permission | Description |
+|---|---|---|
+| `/facebookembed toggle` | Admin | Enable or disable the embed fix for this guild |
+
+## Behavior
+
+| URL type | Handling |
+|---|---|
+| Reels, videos, `fb.watch` | Rewritten to `facebed.seria.moe` (playable media) |
+| Posts (`/<page>/posts/...`) | Native multi-image gallery embed |
+| Events (`/events/...`) | Native embed with title, image, and details |
+| Pages (`/<page>`) | Native embed with name, bio, and profile image |
+| Stories (`/stories/...`) | Skipped (cannot be embedded) |
+
+- Disabled by default; enable per guild with `/facebookembed toggle`.
+- URLs wrapped in `<angle brackets>` or `||spoilers||` are ignored.
+
+## Notes
+
+- Reels and videos can't be embedded natively. The media lives on signed, short-lived `fbcdn.net` URLs that only a scraping service like facebed can resolve.
+- Stories are login-walled to everyone unauthenticated, so no service or API can embed them; they are left untouched rather than posting a useless "Log in to view" card.
+- Posts and pages are scraped from Facebook's OpenGraph tags, which Facebook serves inconsistently. Fetches retry across user-agents, and posts fall back to the facebed link if no data is returned.

--- a/app/cogs/facebookembed/__init__.py
+++ b/app/cogs/facebookembed/__init__.py
@@ -1,0 +1,1 @@
+from .facebookembed import setup

--- a/app/cogs/facebookembed/facebookembed.py
+++ b/app/cogs/facebookembed/facebookembed.py
@@ -1,0 +1,362 @@
+import asyncio
+import re
+
+import aiohttp
+import discord
+from bs4 import BeautifulSoup
+from cogs.common.embedfixcog import EmbedFixCog
+from cogs.lancocog import UrlHandler
+from discord import app_commands
+from discord.ext import commands
+from main import LancoBot
+from utils.command_utils import is_bot_owner_or_admin
+
+from .models import FacebookEmbedConfig
+
+# First-path segments that denote content types (not page vanity slugs), so a
+# bare facebook.com/<slug> is only a page when <slug> isn't one of these.
+RESERVED_SLUGS = (
+    "events",
+    "reel",
+    "reels",
+    "watch",
+    "stories",
+    "story",
+    "story.php",
+    "share",
+    "groups",
+    "marketplace",
+    "gaming",
+    "media",
+    "photo.php",
+    "permalink.php",
+    "profile.php",
+)
+_RESERVED_LOOKAHEAD = r"(?!(?:" + "|".join(RESERVED_SLUGS) + r")(?:[/?]|$))"
+_PAGE_SHAPE = _RESERVED_LOOKAHEAD + r"[^/\s?]+/?(?:\?\S*)?(?=\s|$)"
+
+# events, posts, and pages are handled natively (facebed returns a login card
+# for events/pages, and wraps posts in a noisy author/stats header). Stories are
+# skipped entirely (login-walled; no service or API can embed them), so facebed
+# would only produce a useless "Log in to view" card. NOT_NATIVE keeps all of
+# those out of the facebed rewrite; everything else (reels, videos, share, ...)
+# still rewrites to facebed.
+NOT_NATIVE = (
+    r"(?!events/|stories/|story(?:\.php|/)|[^/\s]+/posts/|" + _PAGE_SHAPE + r")"
+)
+
+EVENT_PATTERN = re.compile(r"https?://(?:www\.|web\.|m\.)?facebook\.com/events/\S+")
+POST_PATTERN = re.compile(
+    r"https?://(?:www\.|web\.|m\.)?facebook\.com/[^/\s]+/posts/\S+"
+)
+PAGE_PATTERN = re.compile(r"https?://(?:www\.|web\.|m\.)?facebook\.com/" + _PAGE_SHAPE)
+
+_OG_PROPERTY = re.compile(r"^og:")
+
+# Facebook serves OG data inconsistently across user-agents, so the native
+# handlers try both (see get_og_tags_resilient).
+FB_CRAWLER_UA = "facebookexternalhit/1.1"
+BROWSER_UA = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36"
+)
+
+FB_BLUE = discord.Color.from_rgb(8, 102, 255)
+
+
+class FacebookEmbed(
+    EmbedFixCog, name="Facebook Embed Fix", description="Fix Facebook embeds"
+):
+    g = app_commands.Group(name="facebookembed", description="FacebookEmbed commands")
+
+    def __init__(self, bot: LancoBot):
+        # The base EmbedFixCog does a single string replace of `original` with
+        # `replacement`. To avoid leaving the www./m./web. prefix attached to the
+        # replacement host, each host form is matched and swapped in full.
+        facebook_pattern = re.compile(
+            r"https?://(?:www\.|web\.|m\.)?facebook\.com/" + NOT_NATIVE + r"\S+"
+        )
+
+        www_facebook_pattern = re.compile(
+            r"https?://www\.facebook\.com/" + NOT_NATIVE + r"\S+"
+        )
+        web_facebook_pattern = re.compile(
+            r"https?://web\.facebook\.com/" + NOT_NATIVE + r"\S+"
+        )
+        m_facebook_pattern = re.compile(
+            r"https?://m\.facebook\.com/" + NOT_NATIVE + r"\S+"
+        )
+        bare_facebook_pattern = re.compile(
+            r"https?://facebook\.com/" + NOT_NATIVE + r"\S+"
+        )
+
+        fb_watch_pattern = re.compile(r"https?://fb\.watch/\S+")
+
+        super().__init__(
+            bot,
+            "Facebook Embed Fix",
+            [
+                EmbedFixCog.PatternReplacement(
+                    www_facebook_pattern,
+                    "www.facebook.com",
+                    "facebed.seria.moe",
+                ),
+                EmbedFixCog.PatternReplacement(
+                    web_facebook_pattern,
+                    "web.facebook.com",
+                    "facebed.seria.moe",
+                ),
+                EmbedFixCog.PatternReplacement(
+                    m_facebook_pattern,
+                    "m.facebook.com",
+                    "facebed.seria.moe",
+                ),
+                EmbedFixCog.PatternReplacement(
+                    bare_facebook_pattern,
+                    "facebook.com",
+                    "facebed.seria.moe",
+                ),
+                EmbedFixCog.PatternReplacement(
+                    fb_watch_pattern,
+                    "fb.watch",
+                    "facebed.seria.moe/fb.watch",
+                ),
+            ],
+            FacebookEmbedConfig,
+        )
+
+        bot.register_url_handler(
+            UrlHandler(
+                url_pattern=facebook_pattern,
+                cog=self,
+                example_url="https://www.facebook.com/watch/?v=10153231379946729",
+            )
+        )
+        bot.register_url_handler(
+            UrlHandler(
+                url_pattern=fb_watch_pattern,
+                cog=self,
+                example_url="https://fb.watch/abcd1234/",
+            )
+        )
+        bot.register_url_handler(
+            UrlHandler(
+                url_pattern=EVENT_PATTERN,
+                cog=self,
+                example_url="https://www.facebook.com/events/1786466945406243/",
+            )
+        )
+        bot.register_url_handler(
+            UrlHandler(
+                url_pattern=POST_PATTERN,
+                cog=self,
+                example_url="https://www.facebook.com/facebook/posts/123456789",
+            )
+        )
+        bot.register_url_handler(
+            UrlHandler(
+                url_pattern=PAGE_PATTERN,
+                cog=self,
+                example_url="https://www.facebook.com/facebook",
+            )
+        )
+
+    @g.command(name="toggle", description="Toggle Facebook embed fix for this server")
+    @is_bot_owner_or_admin()
+    async def toggle(self, interaction):
+        await super().toggle(interaction)
+
+    def _matched_url(self, message: discord.Message, pattern: re.Pattern):
+        """Return the URL a native handler should act on, or None to skip.
+
+        Applies the shared guards (bot author, embed permission, angle-bracket
+        and spoiler suppression, and the per-guild enabled flag).
+        """
+        if message.author.bot:
+            return None
+        if not message.channel.permissions_for(message.guild.me).embed_links:
+            return None
+
+        match = pattern.search(message.content)
+        if not match:
+            return None
+        if self._is_within_angle_brackets(message.content, match):
+            return None
+        if self._is_within_spoiler_tags(message.content, match):
+            return None
+
+        config = self.config_model.get_or_none(guild_id=message.guild.id)
+        if not config or not config.enabled:
+            return None
+
+        return match.group(0)
+
+    async def _send_fix(self, message: discord.Message, **send_kwargs):
+        """Reply with the fixed embed(s) and suppress the original's preview."""
+        fixed_msg = await message.reply(**send_kwargs)
+        self.fixed_messages[message.id] = fixed_msg.id
+        if message.channel.permissions_for(message.guild.me).manage_messages:
+            await message.edit(suppress=True)
+
+    @commands.Cog.listener("on_message")
+    async def handle_events(self, message: discord.Message):
+        """Native embed for event links (facebed only returns a login card)."""
+        url = self._matched_url(message, EVENT_PATTERN)
+        if not url:
+            return
+
+        self.logger.info(f"Building native event embed for {url}")
+        og = await self.get_og_tags_resilient(url)
+        if not og.get("og:title"):
+            self.logger.info(f"No usable OpenGraph data for {url}")
+            return
+
+        embed = discord.Embed(
+            title=og.get("og:title"),
+            description=og.get("og:description"),
+            url=og.get("og:url", url),
+            color=FB_BLUE,
+        )
+        if og.get("images"):
+            embed.set_image(url=og["images"][0])
+        embed.set_footer(text="Facebook Event")
+        await self._send_fix(message, embed=embed)
+
+    @commands.Cog.listener("on_message")
+    async def handle_posts(self, message: discord.Message):
+        """Native gallery embed for post links, dropping facebed's noisy header.
+
+        Images come from facebed (it lists every photo as an og:image); the post
+        text comes from Facebook's own og:description. Falls back to the facebed
+        link if neither source yields anything usable.
+        """
+        url = self._matched_url(message, POST_PATTERN)
+        if not url:
+            return
+
+        self.logger.info(f"Building native post embed for {url}")
+        facebed_url = re.sub(
+            r"(?:www\.|web\.|m\.)?facebook\.com", "facebed.seria.moe", url
+        )
+
+        facebed_og, facebook_og = await asyncio.gather(
+            self.get_og_tags(facebed_url),
+            self.get_og_tags(url, user_agent=BROWSER_UA),
+        )
+
+        title = facebed_og.get("og:title") or facebook_og.get("og:title")
+        description = facebook_og.get("og:description") or facebed_og.get(
+            "og:description"
+        )
+        images = facebed_og.get("images") or facebook_og.get("images") or []
+
+        if not title and not images:
+            self.logger.info(f"No usable data for {url}, falling back to facebed link")
+            await self._send_fix(message, content=facebed_url)
+            return
+
+        embeds = self._build_gallery_embeds(title, description, url, images)
+        await self._send_fix(message, embeds=embeds)
+
+    @commands.Cog.listener("on_message")
+    async def handle_pages(self, message: discord.Message):
+        """Native embed for bare page/profile links (facebed returns a login card).
+
+        Stays silent if nothing usable is scraped, rather than posting that card.
+        """
+        url = self._matched_url(message, PAGE_PATTERN)
+        if not url:
+            return
+
+        self.logger.info(f"Building native page embed for {url}")
+        og = await self.get_og_tags_resilient(url)
+        if not og.get("og:title"):
+            self.logger.info(f"No usable OpenGraph data for {url}")
+            return
+
+        embed = discord.Embed(
+            title=og.get("og:title"),
+            description=og.get("og:description"),
+            url=og.get("og:url", url),
+            color=FB_BLUE,
+        )
+        if og.get("images"):
+            embed.set_thumbnail(url=og["images"][0])
+        embed.set_footer(text="Facebook")
+        await self._send_fix(message, embed=embed)
+
+    @staticmethod
+    def _build_gallery_embeds(
+        title: str, description: str, url: str, images: list
+    ) -> list:
+        """Build a multi-image gallery.
+
+        Discord merges consecutive embeds sharing the same ``url`` into one
+        image grid (max four), so each extra image is an empty embed reusing the
+        primary embed's url.
+        """
+        if title:
+            title = title[:256]
+        if description and len(description) > 4096:
+            description = description[:4093] + "..."
+
+        primary = discord.Embed(
+            title=title,
+            description=description,
+            url=url,
+            color=FB_BLUE,
+        )
+        primary.set_footer(text="Facebook")
+        if images:
+            primary.set_image(url=images[0])
+
+        embeds = [primary]
+        for image in images[1:4]:
+            extra = discord.Embed(url=url)
+            extra.set_image(url=image)
+            embeds.append(extra)
+        return embeds
+
+    async def get_og_tags_resilient(self, url: str) -> dict:
+        """Fetch OG data, retrying with the other UA if the first returns no title."""
+        for user_agent in (FB_CRAWLER_UA, BROWSER_UA):
+            og = await self.get_og_tags(url, user_agent=user_agent)
+            if og.get("og:title"):
+                return og
+        return {}
+
+    async def get_og_tags(self, url: str, user_agent: str = FB_CRAWLER_UA) -> dict:
+        """Return og:* tags as a dict, plus an "images" list of every og:image.
+
+        Returns {} on any fetch error.
+        """
+        headers = {"User-Agent": user_agent}
+        try:
+            async with aiohttp.ClientSession(headers=headers) as session:
+                async with session.get(url) as response:
+                    if response.status != 200:
+                        self.logger.error(
+                            f"Failed to fetch {url}: status {response.status}"
+                        )
+                        return {}
+                    html = await response.text()
+        except aiohttp.ClientError as e:
+            self.logger.error(f"Error fetching {url}: {e}")
+            return {}
+
+        soup = BeautifulSoup(html, "html.parser")
+        tags = {"images": []}
+        for meta in soup.find_all("meta", property=_OG_PROPERTY):
+            content = meta.get("content")
+            if not content:
+                continue
+            if meta["property"] == "og:image":
+                if content not in tags["images"]:
+                    tags["images"].append(content)
+            else:
+                tags[meta["property"]] = content
+        return tags
+
+
+async def setup(bot):
+    await bot.add_cog(FacebookEmbed(bot))

--- a/app/cogs/facebookembed/models.py
+++ b/app/cogs/facebookembed/models.py
@@ -1,0 +1,6 @@
+from cogs.common.embedfixcog import EmbedFixConfigBase
+
+
+class FacebookEmbedConfig(EmbedFixConfigBase):
+    class Meta:
+        table_name = "facebookembed_config"


### PR DESCRIPTION
# Description

Adds a Facebook embed cog that produces rich previews for Facebook links, addressing the lack of Facebook support alongside the existing Instagram/Twitter/etc. embed fixers.

URLs are routed by type:
- **Reels, videos, `fb.watch`** are rewritten to the facebed service for playable media.
- **Posts** get a native multi-image gallery embed (built from OpenGraph data, dropping facebed's noisy author/stats header).
- **Events** and **pages** get native embeds (facebed only returns a login card for these; Facebook's OpenGraph exposes the real data).
- **Stories** are skipped, since they are login-walled and cannot be embedded by any service or API.

Disabled by default; enabled per-guild via `/facebookembed toggle`.

No new dependencies (`aiohttp` and `beautifulsoup4` are already project deps).

Closes #53