### PR TITLE
feat(system): add token-usage and token-water commands

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -102,6 +102,10 @@ SPOTIFY_SECRET=
 
 # OpenAI API key
 OPENAI_API_KEY=
+# OpenAI Admin API key — requires api.usage.read scope (used by the tokenusage cog)
+OPENAI_ADMIN_KEY=
+# OpenAI project ID to scope usage queries to this project only
+OPENAI_PROJECT_ID=
 # Wolfram Alpha API key
 WOLFRAM_ALPHA_API_KEY=
 # VirusTotal API key

--- a/app/cogs/system/system.py
+++ b/app/cogs/system/system.py
@@ -1,9 +1,11 @@
 import asyncio
 import datetime
 import os
+import time
 from sys import version_info as sysv
 from time import monotonic
 
+import aiohttp
 import discord
 import psutil
 from cogs.lancocog import LancoCog
@@ -12,10 +14,102 @@ from utils.command_utils import is_bot_owner
 from utils.dist_utils import get_bot_version, get_commit_hash
 from utils.network_utils import get_external_ip
 
+USAGE_API = "https://api.openai.com/v1/organization/usage/completions"
+CACHE_TTL = 300  # seconds
+
+# Estimate: ~0.1 mL of water per token (Li et al. 2023, "Making AI Less Thirsty", arxiv.org/abs/2304.03271;
+# OpenAI has not published figures - GPT-5 may consume more, treat this as a conservative lower bound)
+ML_PER_TOKEN = 0.1
+
 
 class SystemCog(LancoCog, name="SystemCog", description="System and admin commands"):
     def __init__(self, bot: commands.Bot):
         super().__init__(bot)
+        self._openai_admin_key = os.getenv("OPENAI_ADMIN_KEY")
+        self._openai_project_id = os.getenv("OPENAI_PROJECT_ID")
+        self._usage_cache: dict[int, tuple[float, datetime.datetime, dict]] = (
+            {}
+        )  # days -> (monotonic, fetched_at, data)
+
+    async def cog_load(self):
+        await super().cog_load()
+        if not self._openai_admin_key:
+            self.logger.warning(
+                "OPENAI_ADMIN_KEY not set - token usage commands will not work"
+            )
+        if not self._openai_project_id:
+            self.logger.warning(
+                "OPENAI_PROJECT_ID not set - usage will reflect entire account, not just this project"
+            )
+
+    async def _fetch_usage(self, start_time: int, end_time: int) -> dict | None:
+        """Fetch usage data, paginating in 31-day windows to stay within API limits."""
+        window = 31 * 86400
+        all_buckets = []
+        chunk_start = start_time
+
+        headers = {"Authorization": f"Bearer {self._openai_admin_key}"}
+        async with aiohttp.ClientSession() as session:
+            while chunk_start < end_time:
+                chunk_end = min(chunk_start + window, end_time)
+                params = {
+                    "start_time": chunk_start,
+                    "end_time": chunk_end,
+                    "bucket_width": "1d",
+                    "group_by": "model",
+                    "limit": 31,
+                }
+                if self._openai_project_id:
+                    params["project_ids"] = self._openai_project_id
+                async with session.get(
+                    USAGE_API, params=params, headers=headers
+                ) as resp:
+                    if resp.status != 200:
+                        body = await resp.text()
+                        self.logger.error(
+                            "OpenAI usage API error %s: %s", resp.status, body
+                        )
+                        return None
+                    data = await resp.json()
+                    all_buckets.extend(data.get("data", []))
+                chunk_start = chunk_end
+
+        return {"data": all_buckets}
+
+    async def _get_usage(self, days: int) -> dict | None:
+        """Return cached usage data for the given day range, fetching if stale."""
+        cached_at, fetched_at, cached_data = self._usage_cache.get(
+            days, (0, None, None)
+        )
+        if cached_data is not None and (time.monotonic() - cached_at) < CACHE_TTL:
+            self.logger.debug("Returning cached usage data for %d days", days)
+            return cached_data, fetched_at
+
+        now = int(datetime.datetime.now(datetime.timezone.utc).timestamp())
+        start = now - days * 86400
+        data = await self._fetch_usage(start, now)
+        if data is not None:
+            fetched_at = datetime.datetime.now(datetime.timezone.utc)
+            self._usage_cache[days] = (time.monotonic(), fetched_at, data)
+        return data, fetched_at
+
+    def _aggregate_usage(self, data: dict) -> tuple[dict[str, dict], int, int]:
+        """Returns (per_model totals, grand input tokens, grand output tokens)."""
+        by_model: dict[str, dict] = {}
+        for bucket in data.get("data", []):
+            for result in bucket.get("results", []):
+                model = result.get("model") or "unknown"
+                inp = result.get("input_tokens", 0) or 0
+                out = result.get("output_tokens", 0) or 0
+                cached = result.get("input_cached_tokens", 0) or 0
+                if model not in by_model:
+                    by_model[model] = {"input": 0, "output": 0, "cached": 0}
+                by_model[model]["input"] += inp
+                by_model[model]["output"] += out
+                by_model[model]["cached"] += cached
+        total_in = sum(v["input"] for v in by_model.values())
+        total_out = sum(v["output"] for v in by_model.values())
+        return by_model, total_in, total_out
 
     @discord.app_commands.command(name="ping", description="Ping the bot")
     async def ping(self, interaction: discord.Interaction):
@@ -184,6 +278,187 @@ class SystemCog(LancoCog, name="SystemCog", description="System and admin comman
         await interaction.response.send_message(
             f"Unblocked {user.mention}", ephemeral=True
         )
+
+    @discord.app_commands.command(
+        name="token-usage", description="Show OpenAI token usage"
+    )
+    @discord.app_commands.describe(
+        days="Number of past days to include (default 30, max 90)"
+    )
+    @is_bot_owner()
+    async def token_usage(self, interaction: discord.Interaction, days: int = 30):
+        if not self._openai_admin_key:
+            await interaction.response.send_message(
+                "OPENAI_ADMIN_KEY is not configured."
+            )
+            return
+
+        days = max(1, min(days, 90))
+        await interaction.response.defer()
+
+        data, fetched_at = await self._get_usage(days)
+        if data is None:
+            await interaction.followup.send(
+                "Failed to fetch usage data. Check logs for details."
+            )
+            return
+
+        by_model, total_in, total_out = self._aggregate_usage(data)
+        if not by_model:
+            await interaction.followup.send(
+                f"No usage data found for the past {days} day(s)."
+            )
+            return
+
+        total = total_in + total_out
+        embed = discord.Embed(
+            title=f"OpenAI Token Usage - Past {days} day(s)",
+            description=f"**{total:,}** total tokens  *{total_in:,} in / {total_out:,} out*",
+            color=discord.Color.blurple(),
+        )
+
+        lines = []
+        for model, counts in sorted(
+            by_model.items(), key=lambda x: -(x[1]["input"] + x[1]["output"])
+        ):
+            t = counts["input"] + counts["output"]
+            pct = (t / total * 100) if total else 0
+            cached_note = (
+                f"  *({counts['cached']:,} cached)*" if counts["cached"] else ""
+            )
+            lines.append(
+                f"`{model}`\n"
+                f"↑ {counts['input']:,}  ↓ {counts['output']:,}  *{t:,} ({pct:.1f}%)*{cached_note}"
+            )
+        embed.add_field(name="Model Breakdown", value="\n\n".join(lines), inline=False)
+        embed.set_footer(
+            text=f"Updated {fetched_at.strftime('%b %d, %Y %I:%M %p')} UTC"
+        )
+
+        await interaction.followup.send(embed=embed)
+
+    @token_usage.error
+    async def token_usage_error(
+        self,
+        interaction: discord.Interaction,
+        error: discord.app_commands.AppCommandError,
+    ):
+        if isinstance(error, discord.app_commands.CheckFailure):
+            await interaction.response.send_message(
+                "You don't have permission to use this command."
+            )
+        else:
+            self.logger.error("token_usage error: %s", error)
+
+    @discord.app_commands.command(
+        name="token-water", description="Estimate water consumed by OpenAI token usage"
+    )
+    @discord.app_commands.describe(
+        days="Number of past days to include (default 30, max 90)"
+    )
+    @is_bot_owner()
+    async def token_water(self, interaction: discord.Interaction, days: int = 30):
+        if not self._openai_admin_key:
+            await interaction.response.send_message(
+                "OPENAI_ADMIN_KEY is not configured."
+            )
+            return
+
+        days = max(1, min(days, 90))
+        await interaction.response.defer()
+
+        data, fetched_at = await self._get_usage(days)
+        if data is None:
+            await interaction.followup.send(
+                "Failed to fetch usage data. Check logs for details."
+            )
+            return
+
+        by_model, total_in, total_out = self._aggregate_usage(data)
+        if not by_model:
+            await interaction.followup.send(
+                f"No usage data found for the past {days} day(s)."
+            )
+            return
+
+        total_tokens = total_in + total_out
+        total_ml = total_tokens * ML_PER_TOKEN
+        total_liters = total_ml / 1000
+
+        baja_blasts = total_ml / 709  # large Taco Bell Baja Blast (24 oz)
+        showers = total_ml / 60_000  # 8-min shower (~60 L)
+        turkey_hill_jugs = total_ml / 1_900  # Turkey Hill iced tea half-gallon jug
+        longs_park_lake = total_ml / 11_400_000  # Long's Park lake (~3 million gal)
+        susquehanna_secs = (
+            total_ml / 425_000_000
+        )  # seconds of Susquehanna River flow near Lancaster
+
+        def _fmt(n: float) -> str:
+            if n == 0:
+                return "0"
+            if n < 0.0001:
+                return f"{n:.2e}"
+            if n < 0.01:
+                return f"{n:.6f}"
+            if n < 1:
+                return f"{n:.3f}"
+            return f"{n:,.2f}"
+
+        conversions = [
+            ("Baja Blasts (large)", baja_blasts),
+            ("8-min showers", showers),
+            ("Turkey Hill iced tea jugs", turkey_hill_jugs),
+            ("Long's Park lakes", longs_park_lake),
+            ("seconds of Susquehanna River flow", susquehanna_secs),
+        ]
+
+        embed = discord.Embed(
+            title=f"Estimated Water Usage - Past {days} day(s)",
+            description=f"**{total_liters:,.3f} L** from **{total_tokens:,}** tokens",
+            color=discord.Color.blue(),
+        )
+        embed.add_field(
+            name="That's roughly...",
+            value="\n".join(f"{label}: **{_fmt(val)}**" for label, val in conversions),
+            inline=False,
+        )
+
+        lines = []
+        for model, counts in sorted(
+            by_model.items(), key=lambda x: -(x[1]["input"] + x[1]["output"])
+        ):
+            t = counts["input"] + counts["output"]
+            ml = t * ML_PER_TOKEN
+            lines.append(f"`{model}`  {ml:,.1f} mL  *({t:,} tokens)*")
+        embed.add_field(name="By Model", value="\n".join(lines), inline=False)
+
+        embed.add_field(
+            name="Methodology",
+            value=(
+                f"{ML_PER_TOKEN} mL/token - loosely derived from [Making AI Less Thirsty (Li et al., 2023)](https://arxiv.org/abs/2304.03271).\n\n"
+                f"*Actual water consumption depends on data center location, cooling infrastructure, energy source, utilization rate, and model architecture - "
+                f"none of which are publicly disclosed by OpenAI. Token count is also a poor proxy for compute, as the same token count can represent vastly "
+                f"different amounts of work depending on the model. Treat these numbers as loose illustration, not measurement.*"
+            ),
+            inline=False,
+        )
+        embed.set_footer(
+            text=f"Updated {fetched_at.strftime('%b %d, %Y %I:%M %p')} UTC"
+        )
+        await interaction.followup.send(embed=embed)
+
+    @token_water.error
+    async def token_water_error(
+        self,
+        interaction: discord.Interaction,
+        error: discord.app_commands.AppCommandError,
+    ):
+        if isinstance(error, discord.app_commands.CheckFailure):
+            await interaction.response.send_message(
+                "You don't have permission to use this command."
+            )
+        else:
+            self.logger.error("token_water error: %s", error)
 
 
 async def setup(bot: commands.Bot):

--- a/app/cogs/system/system.py
+++ b/app/cogs/system/system.py
@@ -1,9 +1,11 @@
 import asyncio
 import datetime
 import os
+import time
 from sys import version_info as sysv
 from time import monotonic
 
+import aiohttp
 import discord
 import psutil
 from cogs.lancocog import LancoCog
@@ -12,10 +14,90 @@ from utils.command_utils import is_bot_owner
 from utils.dist_utils import get_bot_version, get_commit_hash
 from utils.network_utils import get_external_ip
 
+USAGE_API = "https://api.openai.com/v1/organization/usage/completions"
+CACHE_TTL = 300  # seconds
+
+# Estimate: ~0.1 mL of water per token (Li et al. 2023, "Making AI Less Thirsty", arxiv.org/abs/2304.03271;
+# OpenAI has not published figures - GPT-5 may consume more, treat this as a conservative lower bound)
+ML_PER_TOKEN = 0.1
+
 
 class SystemCog(LancoCog, name="SystemCog", description="System and admin commands"):
     def __init__(self, bot: commands.Bot):
         super().__init__(bot)
+        self._openai_admin_key = os.getenv("OPENAI_ADMIN_KEY")
+        self._openai_project_id = os.getenv("OPENAI_PROJECT_ID")
+        self._usage_cache: dict[int, tuple[float, datetime.datetime, dict]] = {}  # days -> (monotonic, fetched_at, data)
+
+    async def cog_load(self):
+        await super().cog_load()
+        if not self._openai_admin_key:
+            self.logger.warning("OPENAI_ADMIN_KEY not set - token usage commands will not work")
+        if not self._openai_project_id:
+            self.logger.warning("OPENAI_PROJECT_ID not set - usage will reflect entire account, not just this project")
+
+    async def _fetch_usage(self, start_time: int, end_time: int) -> dict | None:
+        """Fetch usage data, paginating in 31-day windows to stay within API limits."""
+        window = 31 * 86400
+        all_buckets = []
+        chunk_start = start_time
+
+        headers = {"Authorization": f"Bearer {self._openai_admin_key}"}
+        async with aiohttp.ClientSession() as session:
+            while chunk_start < end_time:
+                chunk_end = min(chunk_start + window, end_time)
+                params = {
+                    "start_time": chunk_start,
+                    "end_time": chunk_end,
+                    "bucket_width": "1d",
+                    "group_by": "model",
+                    "limit": 31,
+                }
+                if self._openai_project_id:
+                    params["project_ids"] = self._openai_project_id
+                async with session.get(USAGE_API, params=params, headers=headers) as resp:
+                    if resp.status != 200:
+                        body = await resp.text()
+                        self.logger.error("OpenAI usage API error %s: %s", resp.status, body)
+                        return None
+                    data = await resp.json()
+                    all_buckets.extend(data.get("data", []))
+                chunk_start = chunk_end
+
+        return {"data": all_buckets}
+
+    async def _get_usage(self, days: int) -> dict | None:
+        """Return cached usage data for the given day range, fetching if stale."""
+        cached_at, fetched_at, cached_data = self._usage_cache.get(days, (0, None, None))
+        if cached_data is not None and (time.monotonic() - cached_at) < CACHE_TTL:
+            self.logger.debug("Returning cached usage data for %d days", days)
+            return cached_data, fetched_at
+
+        now = int(datetime.datetime.now(datetime.timezone.utc).timestamp())
+        start = now - days * 86400
+        data = await self._fetch_usage(start, now)
+        if data is not None:
+            fetched_at = datetime.datetime.now(datetime.timezone.utc)
+            self._usage_cache[days] = (time.monotonic(), fetched_at, data)
+        return data, fetched_at
+
+    def _aggregate_usage(self, data: dict) -> tuple[dict[str, dict], int, int]:
+        """Returns (per_model totals, grand input tokens, grand output tokens)."""
+        by_model: dict[str, dict] = {}
+        for bucket in data.get("data", []):
+            for result in bucket.get("results", []):
+                model = result.get("model") or "unknown"
+                inp = result.get("input_tokens", 0) or 0
+                out = result.get("output_tokens", 0) or 0
+                cached = result.get("input_cached_tokens", 0) or 0
+                if model not in by_model:
+                    by_model[model] = {"input": 0, "output": 0, "cached": 0}
+                by_model[model]["input"] += inp
+                by_model[model]["output"] += out
+                by_model[model]["cached"] += cached
+        total_in = sum(v["input"] for v in by_model.values())
+        total_out = sum(v["output"] for v in by_model.values())
+        return by_model, total_in, total_out
 
     @discord.app_commands.command(name="ping", description="Ping the bot")
     async def ping(self, interaction: discord.Interaction):
@@ -184,6 +266,143 @@ class SystemCog(LancoCog, name="SystemCog", description="System and admin comman
         await interaction.response.send_message(
             f"Unblocked {user.mention}", ephemeral=True
         )
+
+    @discord.app_commands.command(name="token-usage", description="Show OpenAI token usage")
+    @discord.app_commands.describe(days="Number of past days to include (default 30, max 90)")
+    @is_bot_owner()
+    async def token_usage(self, interaction: discord.Interaction, days: int = 30):
+        if not self._openai_admin_key:
+            await interaction.response.send_message("OPENAI_ADMIN_KEY is not configured.")
+            return
+
+        days = max(1, min(days, 90))
+        await interaction.response.defer()
+
+        data, fetched_at = await self._get_usage(days)
+        if data is None:
+            await interaction.followup.send("Failed to fetch usage data. Check logs for details.")
+            return
+
+        by_model, total_in, total_out = self._aggregate_usage(data)
+        if not by_model:
+            await interaction.followup.send(f"No usage data found for the past {days} day(s).")
+            return
+
+        total = total_in + total_out
+        embed = discord.Embed(
+            title=f"OpenAI Token Usage - Past {days} day(s)",
+            description=f"**{total:,}** total tokens  *{total_in:,} in / {total_out:,} out*",
+            color=discord.Color.blurple(),
+        )
+
+        lines = []
+        for model, counts in sorted(by_model.items(), key=lambda x: -(x[1]["input"] + x[1]["output"])):
+            t = counts["input"] + counts["output"]
+            pct = (t / total * 100) if total else 0
+            cached_note = f"  *({counts['cached']:,} cached)*" if counts["cached"] else ""
+            lines.append(
+                f"`{model}`\n"
+                f"↑ {counts['input']:,}  ↓ {counts['output']:,}  *{t:,} ({pct:.1f}%)*{cached_note}"
+            )
+        embed.add_field(name="Model Breakdown", value="\n\n".join(lines), inline=False)
+        embed.set_footer(text=f"Updated {fetched_at.strftime('%b %d, %Y %I:%M %p')} UTC")
+
+        await interaction.followup.send(embed=embed)
+
+    @token_usage.error
+    async def token_usage_error(self, interaction: discord.Interaction, error: discord.app_commands.AppCommandError):
+        if isinstance(error, discord.app_commands.CheckFailure):
+            await interaction.response.send_message("You don't have permission to use this command.")
+        else:
+            self.logger.error("token_usage error: %s", error)
+
+    @discord.app_commands.command(name="token-water", description="Estimate water consumed by OpenAI token usage")
+    @discord.app_commands.describe(days="Number of past days to include (default 30, max 90)")
+    @is_bot_owner()
+    async def token_water(self, interaction: discord.Interaction, days: int = 30):
+        if not self._openai_admin_key:
+            await interaction.response.send_message("OPENAI_ADMIN_KEY is not configured.")
+            return
+
+        days = max(1, min(days, 90))
+        await interaction.response.defer()
+
+        data, fetched_at = await self._get_usage(days)
+        if data is None:
+            await interaction.followup.send("Failed to fetch usage data. Check logs for details.")
+            return
+
+        by_model, total_in, total_out = self._aggregate_usage(data)
+        if not by_model:
+            await interaction.followup.send(f"No usage data found for the past {days} day(s).")
+            return
+
+        total_tokens = total_in + total_out
+        total_ml = total_tokens * ML_PER_TOKEN
+        total_liters = total_ml / 1000
+
+        baja_blasts      = total_ml / 709           # large Taco Bell Baja Blast (24 oz)
+        showers          = total_ml / 60_000        # 8-min shower (~60 L)
+        turkey_hill_jugs = total_ml / 1_900         # Turkey Hill iced tea half-gallon jug
+        longs_park_lake  = total_ml / 11_400_000    # Long's Park lake (~3 million gal)
+        susquehanna_secs = total_ml / 425_000_000   # seconds of Susquehanna River flow near Lancaster
+
+        def _fmt(n: float) -> str:
+            if n == 0:
+                return "0"
+            if n < 0.0001:
+                return f"{n:.2e}"
+            if n < 0.01:
+                return f"{n:.6f}"
+            if n < 1:
+                return f"{n:.3f}"
+            return f"{n:,.2f}"
+
+        conversions = [
+            ("Baja Blasts (large)",                baja_blasts),
+            ("8-min showers",                      showers),
+            ("Turkey Hill iced tea jugs",          turkey_hill_jugs),
+            ("Long's Park lakes",                  longs_park_lake),
+            ("seconds of Susquehanna River flow",  susquehanna_secs),
+        ]
+
+        embed = discord.Embed(
+            title=f"Estimated Water Usage - Past {days} day(s)",
+            description=f"**{total_liters:,.3f} L** from **{total_tokens:,}** tokens",
+            color=discord.Color.blue(),
+        )
+        embed.add_field(
+            name="That's roughly...",
+            value="\n".join(f"{label}: **{_fmt(val)}**" for label, val in conversions),
+            inline=False,
+        )
+
+        lines = []
+        for model, counts in sorted(by_model.items(), key=lambda x: -(x[1]["input"] + x[1]["output"])):
+            t = counts["input"] + counts["output"]
+            ml = t * ML_PER_TOKEN
+            lines.append(f"`{model}`  {ml:,.1f} mL  *({t:,} tokens)*")
+        embed.add_field(name="By Model", value="\n".join(lines), inline=False)
+
+        embed.add_field(
+            name="Methodology",
+            value=(
+                f"{ML_PER_TOKEN} mL/token - loosely derived from [Making AI Less Thirsty (Li et al., 2023)](https://arxiv.org/abs/2304.03271).\n\n"
+                f"*Actual water consumption depends on data center location, cooling infrastructure, energy source, utilization rate, and model architecture - "
+                f"none of which are publicly disclosed by OpenAI. Token count is also a poor proxy for compute, as the same token count can represent vastly "
+                f"different amounts of work depending on the model. Treat these numbers as loose illustration, not measurement.*"
+            ),
+            inline=False,
+        )
+        embed.set_footer(text=f"Updated {fetched_at.strftime('%b %d, %Y %I:%M %p')} UTC")
+        await interaction.followup.send(embed=embed)
+
+    @token_water.error
+    async def token_water_error(self, interaction: discord.Interaction, error: discord.app_commands.AppCommandError):
+        if isinstance(error, discord.app_commands.CheckFailure):
+            await interaction.response.send_message("You don't have permission to use this command.")
+        else:
+            self.logger.error("token_water error: %s", error)
 
 
 async def setup(bot: commands.Bot):

--- a/app/utils/ai_utils.py
+++ b/app/utils/ai_utils.py
@@ -20,13 +20,17 @@ async def _noop(_: str) -> None:
 async def run_agent(
     agent_call: Callable[[], Awaitable[AgentRunResult]],
     on_error: Callable[[str], Awaitable[None]] = _noop,
+    *,
+    model_name: str | None = None,
+    cog_name: str | None = None,
 ) -> AgentRunResult | None:
     """Run a pydantic-ai agent call, invoking on_error with a user-facing message on failure.
 
+    Pass model_name and cog_name to record token usage for the /token-usage command.
     Returns the result on success, or None if an error occurred.
     """
     try:
-        return await agent_call()
+        result = await agent_call()
     except ModelHTTPError as e:
         logger.error("ModelHTTPError during agent run: %s", e)
         await on_error(_http_error_msg(e))
@@ -35,3 +39,13 @@ async def run_agent(
         logger.error("Unexpected error during agent run: %s", e)
         await on_error("Something went wrong on my end.\nTry again later!")
         return None
+
+    if model_name or cog_name:
+        try:
+            from utils.token_tracker import record_usage
+
+            record_usage(model_name or "unknown", cog_name or "unknown", result.usage())
+        except Exception:
+            logger.debug("Failed to record token usage", exc_info=True)
+
+    return result


### PR DESCRIPTION
# Description

Adds two owner-only slash commands to the system cog:

- `/token-usage [days]` - pulls token usage from the OpenAI organization API, broken down by model with input/output counts and percentages
- `/token-water [days]` - estimates water consumption from that usage

Results are cached for 5 minutes. Requires `OPENAI_ADMIN_KEY` (api.usage.read scope) and `OPENAI_PROJECT_ID` in `.env`.