### PR TITLE
fix(core): improve sqlite concurrency and migration reliability

### DIFF
--- a/app/cogs/geoguesser/geoguesser.py
+++ b/app/cogs/geoguesser/geoguesser.py
@@ -811,24 +811,23 @@ class GeoGuesser(
 
                 thread_db = SqliteDatabase(os.getenv("SQLITE_DB"))
                 thread_db.connect()
-                LocationModel.bind(thread_db)
                 try:
-                    with thread_db.atomic():
-                        LocationModel.delete().where(
-                            LocationModel.mode == mode.name
-                        ).execute()
-                        for location in locations:
-                            LocationModel.create(
-                                mode=mode.name,
-                                initial_lat=location.initial_location.lat,
-                                initial_lng=location.initial_location.lng,
-                                road_lat=location.road_coords.lat,
-                                road_lng=location.road_coords.lng,
-                                label=location.label,
-                            )
+                    with LocationModel.bind_ctx(thread_db):
+                        with thread_db.atomic():
+                            LocationModel.delete().where(
+                                LocationModel.mode == mode.name
+                            ).execute()
+                            for location in locations:
+                                LocationModel.create(
+                                    mode=mode.name,
+                                    initial_lat=location.initial_location.lat,
+                                    initial_lng=location.initial_location.lng,
+                                    road_lat=location.road_coords.lat,
+                                    road_lng=location.road_coords.lng,
+                                    label=location.label,
+                                )
                     return locations
                 finally:
-                    LocationModel.bind(self.bot.database)
                     thread_db.close()
 
             task = asyncio.create_task(asyncio.to_thread(generate_and_save))

--- a/app/cogs/incidents/incidents.py
+++ b/app/cogs/incidents/incidents.py
@@ -125,11 +125,11 @@ class Incidents(LancoCog, name="Incidents", description="LCWC Incident feed"):
 
                     if self.is_using_arcgis():
                         feed_config.last_known_incident = incident.number
-                        feed_config.save()
                     else:
-                        incident_timestamp = incident.date.timestamp()
-                        feed_config.latest_incident_timestamp = incident_timestamp
-                        feed_config.save()
+                        feed_config.latest_incident_timestamp = (
+                            incident.date.timestamp()
+                        )
+                    feed_config.save()
 
     def is_using_arcgis(self) -> bool:
         return isinstance(self.current_client, ArcGISClient)

--- a/app/cogs/redditfeed/redditfeed.py
+++ b/app/cogs/redditfeed/redditfeed.py
@@ -172,12 +172,11 @@ class RedditFeed(LancoCog, name="RedditFeed", description="Reddit feed polling")
                         last_updated=now,
                         message_id=msg.id,
                     )
-
-                # Mark as seen and update last known post creation
-                seen_ids.add(submission.id)
-                for config in configs:
                     config.last_known_post_creation = submission.created_utc
                     config.save()
+
+                # Mark as seen
+                seen_ids.add(submission.id)
                 self.logger.info(f"[{sr}] Marked {submission.id} as seen")
 
     async def update_post_states(self):

--- a/app/main.py
+++ b/app/main.py
@@ -17,6 +17,7 @@ from discord.ext import commands
 from dotenv import load_dotenv
 from logtail import LogtailHandler
 from peewee import *
+from playhouse.sqliteq import SqliteQueueDatabase
 from utils.command_utils import is_bot_owner
 from utils.router import ImageRouter, Intent
 from watchfiles import Change, awatch
@@ -255,7 +256,7 @@ def get_prefix(bot, message):
     return DEFAULT_PREFIX
 
 
-def init_db() -> SqliteDatabase:
+def init_db() -> Database:
     """Initialize and connect the database, returning the database instance."""
     db_type_str = os.getenv("DB_TYPE", "sqlite")
 
@@ -271,7 +272,16 @@ def init_db() -> SqliteDatabase:
         db_dir = os.path.dirname(sqlite_path)
         if db_dir and not os.path.exists(db_dir):
             os.makedirs(db_dir)
-        db = SqliteDatabase(sqlite_path)
+        db = SqliteQueueDatabase(
+            sqlite_path,
+            pragmas={
+                "journal_mode": "wal",
+                "cache_size": -1024 * 32,
+                "foreign_keys": 1,
+            },
+            thread_safe=True,
+            timeout=5,
+        )
 
     elif db_type == DatabaseType.MYSQL:
         db = MySQLDatabase(
@@ -742,7 +752,7 @@ async def main():
         if config.prefix:
             _prefix_cache[config.guild_id] = config.prefix
 
-    db_backup = DatabaseBackup()
+    db_backup = DatabaseBackup(database=database)
     await bot.load_cogs()
     async with bot:
         db_backup.start()

--- a/app/utils/config.py
+++ b/app/utils/config.py
@@ -4,7 +4,7 @@ from peewee import *
 
 
 class GuildConfig(BaseModel):
-    guild_id = IntegerField()
+    guild_id = IntegerField(unique=True)
     prefix = CharField(default=".")
     timezone = CharField(default="UTC")
 

--- a/app/utils/db_backup.py
+++ b/app/utils/db_backup.py
@@ -8,7 +8,8 @@ logger = logging.getLogger(__name__)
 
 
 class DatabaseBackup:
-    def __init__(self):
+    def __init__(self, database=None):
+        self.database = database
         self.backup_dir = os.getenv("DATABASE_BACKUP_DIRECTORY", "db_backups")
         self.backup_filename = os.getenv("DATABASE_BACKUP_FILENAME", "db_backup_{}.db")
         self.backup_interval = int(os.getenv("DATABASE_BACKUP_INTERVAL", 86400))
@@ -48,6 +49,8 @@ class DatabaseBackup:
 
         logger.info(f"Backing up database to {dest}")
         try:
+            if self.database:
+                self.database.execute_sql("PRAGMA wal_checkpoint(TRUNCATE)")
             await asyncio.to_thread(shutil.copy2, self.database_path, dest)
             logger.info(f"Database backed up to {dest}")
             await asyncio.to_thread(self._prune_old_backups)

--- a/app/utils/tracked_message.py
+++ b/app/utils/tracked_message.py
@@ -14,8 +14,7 @@ class TrackedMessage(BaseModel):
 
 def create_tables():
     """Create the tables"""
-    with BaseModel._meta.database:
-        BaseModel._meta.database.create_tables([TrackedMessage])
+    BaseModel._meta.database.create_tables([TrackedMessage])
 
 
 def is_message_tracked(message_id: int) -> bool:

--- a/migrate.py
+++ b/migrate.py
@@ -1,12 +1,39 @@
 # migrate.py
 
+import datetime
 import importlib.util
 import os
 
+from dotenv import load_dotenv
+from peewee import *
+
+load_dotenv()
+
 MIGRATIONS_DIR = "migrations"
 
+_db_path = os.getenv("SQLITE_DB", "data/lancobot.db")
+_db = SqliteDatabase(_db_path)
 
-def run_migration_script(script_path):
+
+class SchemaMigration(Model):
+    name = CharField(unique=True)
+    applied_at = DateTimeField(default=datetime.datetime.now)
+
+    class Meta:
+        database = _db
+        table_name = "schema_migrations"
+
+
+def _ensure_tracking_table():
+    _db.connect(reuse_if_open=True)
+    _db.create_tables([SchemaMigration], safe=True)
+
+
+def _applied_migrations() -> set:
+    return {row.name for row in SchemaMigration.select()}
+
+
+def _run_migration_script(script_path):
     spec = importlib.util.spec_from_file_location("migration", script_path)
     migration = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(migration)
@@ -14,13 +41,21 @@ def run_migration_script(script_path):
 
 
 def run_migrations():
-    migrations = sorted(os.listdir(MIGRATIONS_DIR))
+    _ensure_tracking_table()
+    applied = _applied_migrations()
+
+    migrations = sorted(f for f in os.listdir(MIGRATIONS_DIR) if f.endswith(".py"))
+
     for migration in migrations:
-        if migration.endswith(".py"):
-            migration_path = os.path.join(MIGRATIONS_DIR, migration)
-            print(f"Running migration: {migration}...", end="")
-            run_migration_script(migration_path)
-            print(" Done.")
+        if migration in applied:
+            print(f"Skipping {migration} (already applied)")
+            continue
+
+        migration_path = os.path.join(MIGRATIONS_DIR, migration)
+        print(f"Running migration: {migration}...", end="", flush=True)
+        _run_migration_script(migration_path)
+        SchemaMigration.create(name=migration)
+        print(" Done.")
 
 
 if __name__ == "__main__":

--- a/migrations/015_guild_config_unique_guild_id.py
+++ b/migrations/015_guild_config_unique_guild_id.py
@@ -1,0 +1,38 @@
+import os
+
+from dotenv import load_dotenv
+from peewee import *
+
+load_dotenv()
+
+db = SqliteDatabase(os.getenv("SQLITE_DB"))
+
+TABLE = "guild_configs"
+
+
+def run():
+    db.connect(reuse_if_open=True)
+
+    if TABLE not in db.get_tables():
+        print(f"Table '{TABLE}' does not exist. No changes made.")
+        return
+
+    # Deduplicate: keep the row with the lowest rowid for each guild_id.
+    db.execute_sql(f"""
+        DELETE FROM {TABLE}
+        WHERE rowid NOT IN (
+            SELECT MIN(rowid) FROM {TABLE} GROUP BY guild_id
+        )
+    """)
+
+    # SQLite doesn't support ADD CONSTRAINT on existing tables, so we
+    # recreate the table with a unique index on guild_id instead.
+    indexes = db.get_indexes(TABLE)
+    index_names = [idx.name for idx in indexes]
+    if "guild_configs_guild_id" not in index_names:
+        db.execute_sql(
+            f"CREATE UNIQUE INDEX guild_configs_guild_id ON {TABLE} (guild_id)"
+        )
+        print(f"Added unique index on {TABLE}.guild_id")
+    else:
+        print("Unique index on guild_id already exists. No changes made.")


### PR DESCRIPTION
## Summary

- Switches `SqliteDatabase` to `SqliteQueueDatabase` with WAL mode, serializing concurrent async writes through an internal queue to eliminate `database is locked` errors
- Fixes a race condition in geoguesser's thread-based location generation by replacing manual `LocationModel.bind()`/`bind()` bookends with `bind_ctx()` as a context manager
- Adds a `PRAGMA wal_checkpoint(TRUNCATE)` before the file copy in `db_backup` so backups are always consistent
- Adds `unique=True` to `GuildConfig.guild_id` + migration `015` to deduplicate existing rows and add the unique index
- Adds a `SchemaMigration` tracking table to `migrate.py` so re-running migrations skips already-applied ones