### PR TITLE
feat(embedfix): add per-guild handler switching"

### DIFF
--- a/app/cogs/common/embedfixcog.py
+++ b/app/cogs/common/embedfixcog.py
@@ -5,32 +5,89 @@ import discord
 from cachetools import LRUCache
 from cogs.lancocog import LancoCog
 from db import BaseModel
+from discord import app_commands
 from discord.ext import commands
 from peewee import *
+
+
+class _HandlerSelect(discord.ui.Select):
+    def __init__(self, cog: "EmbedFixCog", guild_id: int, active_id: str):
+        self._cog = cog
+        self._guild_id = guild_id
+        options = [
+            discord.SelectOption(
+                label=h.name,
+                description=h.description[:100],
+                value=h.id,
+                default=(h.id == active_id),
+            )
+            for h in cog.handlers
+        ]
+        super().__init__(placeholder="Select a handler…", options=options)
+
+    async def callback(self, interaction: discord.Interaction):
+        handler_id = self.values[0]
+        handler = next(h for h in self._cog.handlers if h.id == handler_id)
+
+        config, _ = self._cog.config_model.get_or_create(guild_id=self._guild_id)
+        config.handler_id = handler_id
+        config.save()
+
+        await interaction.response.edit_message(
+            content=f"Handler set to **{handler.name}** — {handler.description}.",
+            view=None,
+        )
+
+
+class _HandlerSelectView(discord.ui.View):
+    def __init__(
+        self, cog: "EmbedFixCog", guild_id: int, active_id: str, invoker_id: int
+    ):
+        super().__init__(timeout=60)
+        self._invoker_id = invoker_id
+        self.add_item(_HandlerSelect(cog, guild_id, active_id))
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        if interaction.user.id != self._invoker_id:
+            await interaction.response.send_message(
+                "Only the person who ran this command can use this menu.",
+                ephemeral=True,
+            )
+            return False
+        return True
 
 
 class EmbedFixConfigBase(BaseModel):
     guild_id = BigIntegerField(primary_key=True)
     enabled = BooleanField(default=False)
+    handler_id = CharField(default="")
 
 
 class EmbedFixCog(LancoCog, name="EmbedFixCog", description="Abstract embed fix cog"):
     """Abstract class for fixing embeds to be extended by other cogs"""
 
     class PatternReplacement:
-        """A pattern and its replacement"""
+        """A URL pattern and its domain replacement"""
 
         def __init__(self, pattern: re.Pattern, original: str, replacement: str):
-            """Initialize the pattern and its replacement
-
-            Args:
-                pattern (re.Pattern): The pattern to search for
-                original (str): The original string to replace
-                replacement (str): The replacement for the pattern
-            """
             self.pattern = pattern
             self.original = original
             self.replacement = replacement
+
+    class Handler:
+        """A named embed-fix handler with its own set of pattern replacements"""
+
+        def __init__(
+            self,
+            id: str,
+            name: str,
+            description: str,
+            patterns: list,
+        ):
+            self.id = id
+            self.name = name
+            self.description = description
+            self.patterns = patterns
 
     @staticmethod
     def _is_within_angle_brackets(content: str, match: re.Match) -> bool:
@@ -70,30 +127,27 @@ class EmbedFixCog(LancoCog, name="EmbedFixCog", description="Abstract embed fix 
         self,
         bot: commands.Bot,
         name: str,
-        patterns: list[PatternReplacement],
+        handlers: list,
         config_model: Model,
         skip_if_handled_by_discord: bool = False,
         wait_time: float = 2.5,
     ):
-        """Initialize the cog
-
-        Args:
-            bot (commands.Bot): The bot
-            name: (str) The name of the replacement (e.g. "Twitter")
-            patterns (list[Pattern]): The patterns to search for and their replacements
-            config_model (Model): The model to use for configuration
-            skip_if_handled_by_discord (bool): Whether to skip if discord embeds the link
-            wait_time (float): The time to wait before fixing the embed
-        """
-
         super().__init__(bot)
         self.name = name
-        self.patterns = patterns
+        self.handlers = handlers
         self.config_model = config_model
         self.skip_if_handled_by_discord = skip_if_handled_by_discord
         self.wait_time = wait_time
         self.bot.database.create_tables([self.config_model])
         self.fixed_messages = LRUCache(maxsize=1000)  # message_id -> fixed_message_id
+
+    def _active_handler(self, config) -> "EmbedFixCog.Handler":
+        """Return the configured Handler for this guild, falling back to the first."""
+        if config and config.handler_id:
+            for h in self.handlers:
+                if h.id == config.handler_id:
+                    return h
+        return self.handlers[0]
 
     async def toggle(self, interaction: discord.Interaction):
         config, created = self.config_model.get_or_create(guild_id=interaction.guild.id)
@@ -110,6 +164,25 @@ class EmbedFixCog(LancoCog, name="EmbedFixCog", description="Abstract embed fix 
                 f"{self.name} disabled for this server"
             )
 
+    async def _show_handler_select(self, interaction: discord.Interaction):
+        config = self.config_model.get_or_none(guild_id=interaction.guild.id)
+        active = self._active_handler(config)
+
+        if len(self.handlers) == 1:
+            await interaction.response.send_message(
+                f"**{self.name}** — current handler: **{active.name}** ({active.description})\n"
+                "*No alternative handlers are configured.*"
+            )
+            return
+
+        view = _HandlerSelectView(
+            self, interaction.guild.id, active.id, interaction.user.id
+        )
+        await interaction.response.send_message(
+            f"**{self.name}** — current handler: **{active.name}**\nSelect a handler to switch:",
+            view=view,
+        )
+
     @commands.Cog.listener()
     async def on_message(self, message: discord.Message):
         if message.author.bot:
@@ -121,12 +194,14 @@ class EmbedFixCog(LancoCog, name="EmbedFixCog", description="Abstract embed fix 
         if not message.channel.permissions_for(message.guild.me).embed_links:
             return
 
-        for pr in self.patterns:
+        # Detect using the first handler's patterns (all handlers share the same
+        # regex shapes — only the replacement domain differs between handlers).
+        matched_idx = None
+        original_url = None
+
+        for i, pr in enumerate(self.handlers[0].patterns):
             match = pr.pattern.search(message.content)
             if match:
-                self.logger.info(
-                    f"Found URL matching pattern for {self.name}: {match.group(0)}"
-                )
                 if self._is_within_angle_brackets(message.content, match):
                     self.logger.info("URL is within angle brackets, ignoring")
                     return
@@ -136,32 +211,43 @@ class EmbedFixCog(LancoCog, name="EmbedFixCog", description="Abstract embed fix 
                     return
 
                 original_url = match.group(0)
-                fixed_url = original_url.replace(pr.original, pr.replacement)
+                matched_idx = i
+                break
 
-                self.logger.info(
-                    f"Found URL to be handled by {self.name}: {original_url} -> {fixed_url} - waiting {self.wait_time}s"
-                )
+        if matched_idx is None:
+            return
 
-                # wait a bit to see if discord will embed the link
-                await asyncio.sleep(self.wait_time)
+        self.logger.info(
+            f"Found URL matching pattern for {self.name}: {original_url} - waiting {self.wait_time}s"
+        )
 
-                # re-fetch the message to get the latest content
-                message = await message.channel.fetch_message(message.id)
-                if message.embeds and self.skip_if_handled_by_discord:
-                    self.logger.info("Discord embedded the link, no need to fix it")
-                    return
+        await asyncio.sleep(self.wait_time)
 
-                embed_config = self.config_model.get_or_none(guild_id=message.guild.id)
-                if not embed_config or not embed_config.enabled:
-                    self.logger.info("Embed fix not enabled for this server")
-                    return
+        # re-fetch the message to get the latest content
+        message = await message.channel.fetch_message(message.id)
+        if message.embeds and self.skip_if_handled_by_discord:
+            self.logger.info("Discord embedded the link, no need to fix it")
+            return
 
-                fixed_msg = await message.reply(fixed_url)
-                self.fixed_messages[message.id] = fixed_msg.id
+        embed_config = self.config_model.get_or_none(guild_id=message.guild.id)
+        if not embed_config or not embed_config.enabled:
+            self.logger.info("Embed fix not enabled for this server")
+            return
 
-                # suppress the original embed if we can
-                if message.channel.permissions_for(message.guild.me).manage_messages:
-                    await message.edit(suppress=True)
+        active = self._active_handler(embed_config)
+        pr = active.patterns[min(matched_idx, len(active.patterns) - 1)]
+        fixed_url = original_url.replace(pr.original, pr.replacement)
+
+        self.logger.info(
+            f"Fixing URL with handler '{active.id}': {original_url} -> {fixed_url}"
+        )
+
+        fixed_msg = await message.reply(fixed_url)
+        self.fixed_messages[message.id] = fixed_msg.id
+
+        # suppress the original embed if we can
+        if message.channel.permissions_for(message.guild.me).manage_messages:
+            await message.edit(suppress=True)
 
     @commands.Cog.listener()
     async def on_message_delete(self, message: discord.Message):

--- a/app/cogs/facebookembed/README.md
+++ b/app/cogs/facebookembed/README.md
@@ -8,6 +8,10 @@ Replaces broken Facebook embeds with rich previews. URLs are routed by type: ree
 |---|---|---|
 | `/facebookembed toggle` | Admin | Enable or disable the embed fix for this guild |
 
+## Handler
+
+Facebook uses a single fixed handler (`facebed.seria.moe`). Handler switching is not supported because the native event, post, and page embeds also rely on the facebed service and cannot be easily redirected.
+
 ## Behavior
 
 | URL type | Handling |

--- a/app/cogs/facebookembed/facebookembed.py
+++ b/app/cogs/facebookembed/facebookembed.py
@@ -96,30 +96,37 @@ class FacebookEmbed(
             bot,
             "Facebook Embed Fix",
             [
-                EmbedFixCog.PatternReplacement(
-                    www_facebook_pattern,
-                    "www.facebook.com",
-                    "facebed.seria.moe",
-                ),
-                EmbedFixCog.PatternReplacement(
-                    web_facebook_pattern,
-                    "web.facebook.com",
-                    "facebed.seria.moe",
-                ),
-                EmbedFixCog.PatternReplacement(
-                    m_facebook_pattern,
-                    "m.facebook.com",
-                    "facebed.seria.moe",
-                ),
-                EmbedFixCog.PatternReplacement(
-                    bare_facebook_pattern,
-                    "facebook.com",
-                    "facebed.seria.moe",
-                ),
-                EmbedFixCog.PatternReplacement(
-                    fb_watch_pattern,
-                    "fb.watch",
-                    "facebed.seria.moe/fb.watch",
+                EmbedFixCog.Handler(
+                    "facebed",
+                    "Facebed",
+                    "Uses facebed.seria.moe",
+                    [
+                        EmbedFixCog.PatternReplacement(
+                            www_facebook_pattern,
+                            "www.facebook.com",
+                            "facebed.seria.moe",
+                        ),
+                        EmbedFixCog.PatternReplacement(
+                            web_facebook_pattern,
+                            "web.facebook.com",
+                            "facebed.seria.moe",
+                        ),
+                        EmbedFixCog.PatternReplacement(
+                            m_facebook_pattern,
+                            "m.facebook.com",
+                            "facebed.seria.moe",
+                        ),
+                        EmbedFixCog.PatternReplacement(
+                            bare_facebook_pattern,
+                            "facebook.com",
+                            "facebed.seria.moe",
+                        ),
+                        EmbedFixCog.PatternReplacement(
+                            fb_watch_pattern,
+                            "fb.watch",
+                            "facebed.seria.moe/fb.watch",
+                        ),
+                    ],
                 ),
             ],
             FacebookEmbedConfig,

--- a/app/cogs/instaembed/README.md
+++ b/app/cogs/instaembed/README.md
@@ -1,3 +1,25 @@
 # InstaEmbed
 
-Provides embed support for Instagram posts.
+Fixes Instagram embeds by rewriting links to a third-party fixer service that enables media playback in Discord.
+
+## Commands
+
+| Command | Permission | Description |
+|---|---|---|
+| `/instaembed toggle` | Admin | Enable or disable the embed fix for this guild |
+| `/instaembed handler` | Admin | Switch the fixer service via dropdown |
+
+## Handlers
+
+| ID | Name | Replacement |
+|---|---|---|
+| `zzinstagram` *(default)* | ZZInstagram | `zzinstagram.com` |
+| `ddinstagram` | DDInstagram | `ddinstagram.com` |
+
+Run `/instaembed handler` to get a dropdown of available handlers. The selection is saved per guild and takes effect immediately for new links.
+
+## Behavior
+
+- Matches `instagram.com/p/…`, `/reel/…`, and `/reels/…` URLs.
+- Disabled by default; enable per guild with `/instaembed toggle`.
+- URLs wrapped in `<angle brackets>` or `||spoilers||` are ignored.

--- a/app/cogs/instaembed/instaembed.py
+++ b/app/cogs/instaembed/instaembed.py
@@ -21,10 +21,25 @@ class InstaEmbed(EmbedFixCog, name="InstaEmbed", description="Instagram embed fi
             bot,
             "Instagram Embed Fix",
             [
-                EmbedFixCog.PatternReplacement(
-                    self.insta_pattern,
-                    "instagram.com",
-                    "zzinstagram.com",
+                EmbedFixCog.Handler(
+                    "zzinstagram",
+                    "ZZInstagram",
+                    "Uses zzinstagram.com",
+                    [
+                        EmbedFixCog.PatternReplacement(
+                            self.insta_pattern, "instagram.com", "zzinstagram.com"
+                        ),
+                    ],
+                ),
+                EmbedFixCog.Handler(
+                    "ddinstagram",
+                    "DDInstagram",
+                    "Uses ddinstagram.com",
+                    [
+                        EmbedFixCog.PatternReplacement(
+                            self.insta_pattern, "instagram.com", "ddinstagram.com"
+                        ),
+                    ],
                 ),
             ],
             InstaEmbedConfig,
@@ -42,6 +57,14 @@ class InstaEmbed(EmbedFixCog, name="InstaEmbed", description="Instagram embed fi
     @is_bot_owner_or_admin()
     async def toggle(self, interaction):
         await super().toggle(interaction)
+
+    @g.command(
+        name="handler",
+        description="Switch the Instagram embed handler for this server",
+    )
+    @is_bot_owner_or_admin()
+    async def handler(self, interaction):
+        await self._show_handler_select(interaction)
 
 
 async def setup(bot):

--- a/app/cogs/redditembed/README.md
+++ b/app/cogs/redditembed/README.md
@@ -1,3 +1,22 @@
 # Reddit Embed Fixer
 
-This cog fixes Reddit embeds and supports media playback.
+Fixes Reddit embeds by rewriting links to a third-party fixer service that enables media playback in Discord.
+
+## Commands
+
+| Command | Permission | Description |
+|---|---|---|
+| `/redditembed toggle` | Admin | Enable or disable the embed fix for this guild |
+| `/redditembed handler` | Admin | View the active fixer service |
+
+## Handlers
+
+| ID | Name | Replacement |
+|---|---|---|
+| `rxddit` *(default)* | Rxddit | `rxddit.com` |
+
+## Behavior
+
+- Matches all `reddit.com` URLs.
+- Disabled by default; enable per guild with `/redditembed toggle`.
+- URLs wrapped in `<angle brackets>` or `||spoilers||` are ignored.

--- a/app/cogs/redditembed/redditembed.py
+++ b/app/cogs/redditembed/redditembed.py
@@ -21,11 +21,16 @@ class RedditEmbed(
             bot,
             "Reddit Embed Fix",
             [
-                EmbedFixCog.PatternReplacement(
-                    self.reddit_pattern,
-                    "www.reddit.com",
-                    "rxddit.com",
-                )
+                EmbedFixCog.Handler(
+                    "rxddit",
+                    "Rxddit",
+                    "Uses rxddit.com",
+                    [
+                        EmbedFixCog.PatternReplacement(
+                            self.reddit_pattern, "www.reddit.com", "rxddit.com"
+                        ),
+                    ],
+                ),
             ],
             RedditEmbedConfig,
         )
@@ -42,6 +47,14 @@ class RedditEmbed(
     @is_bot_owner_or_admin()
     async def toggle(self, interaction):
         await super().toggle(interaction)
+
+    @g.command(
+        name="handler",
+        description="Switch the Reddit embed handler for this server",
+    )
+    @is_bot_owner_or_admin()
+    async def handler(self, interaction):
+        await self._show_handler_select(interaction)
 
 
 async def setup(bot):

--- a/app/cogs/tiktokembed/README.md
+++ b/app/cogs/tiktokembed/README.md
@@ -1,3 +1,25 @@
 # TikTok Embed Fixer
 
-This cog fixes TikTok embeds and supports media playback.
+Fixes TikTok embeds by rewriting links to a third-party fixer service that enables media playback in Discord.
+
+## Commands
+
+| Command | Permission | Description |
+|---|---|---|
+| `/tiktokembed toggle` | Admin | Enable or disable the embed fix for this guild |
+| `/tiktokembed handler` | Admin | Switch the fixer service via dropdown |
+
+## Handlers
+
+| ID | Name | Replacement |
+|---|---|---|
+| `vxtiktok` *(default)* | VxTikTok | `vxtiktok.com` |
+| `tnktok` | TnkTok | `tnktok.com` |
+
+Run `/tiktokembed handler` to get a dropdown of available handlers. The selection is saved per guild and takes effect immediately for new links.
+
+## Behavior
+
+- Shop and product URLs (`/shop/…`, `/product/…`) are excluded.
+- Disabled by default; enable per guild with `/tiktokembed toggle`.
+- URLs wrapped in `<angle brackets>` or `||spoilers||` are ignored.

--- a/app/cogs/tiktokembed/tiktokembed.py
+++ b/app/cogs/tiktokembed/tiktokembed.py
@@ -23,10 +23,25 @@ class TikTokEmbed(
             bot,
             "TikTok Embed Fix",
             [
-                EmbedFixCog.PatternReplacement(
-                    self.tiktok_pattern,
-                    "tiktok.com",
-                    "vxtiktok.com",
+                EmbedFixCog.Handler(
+                    "vxtiktok",
+                    "VxTikTok",
+                    "Uses vxtiktok.com",
+                    [
+                        EmbedFixCog.PatternReplacement(
+                            self.tiktok_pattern, "tiktok.com", "vxtiktok.com"
+                        ),
+                    ],
+                ),
+                EmbedFixCog.Handler(
+                    "tnktok",
+                    "TnkTok",
+                    "Uses tnktok.com",
+                    [
+                        EmbedFixCog.PatternReplacement(
+                            self.tiktok_pattern, "tiktok.com", "tnktok.com"
+                        ),
+                    ],
                 ),
             ],
             TikTokEmbedConfig,
@@ -44,6 +59,14 @@ class TikTokEmbed(
     @is_bot_owner_or_admin()
     async def toggle(self, interaction):
         await super().toggle(interaction)
+
+    @g.command(
+        name="handler",
+        description="Switch the TikTok embed handler for this server",
+    )
+    @is_bot_owner_or_admin()
+    async def handler(self, interaction):
+        await self._show_handler_select(interaction)
 
 
 async def setup(bot):

--- a/app/cogs/twitterembed/README.md
+++ b/app/cogs/twitterembed/README.md
@@ -1,3 +1,26 @@
 # Twitter/X Embed Fixer
 
-This cog fixes Twitter/X embeds and supports media playback.
+Fixes Twitter/X embeds by rewriting links to a third-party fixer service that enables media playback in Discord.
+
+## Commands
+
+| Command | Permission | Description |
+|---|---|---|
+| `/twitterembed toggle` | Admin | Enable or disable the embed fix for this guild |
+| `/twitterembed handler` | Admin | Switch the fixer service via dropdown |
+
+## Handlers
+
+| ID | Name | Replacement |
+|---|---|---|
+| `fxtwitter` *(default)* | FxTwitter | `fxtwitter.com` |
+| `vxtwitter` | VxTwitter | `vxtwitter.com` / `fixvx.com` for x.com links |
+| `fixupx` | FixupX | `fixupx.com` |
+
+Run `/twitterembed handler` to get a dropdown of available handlers. The selection is saved per guild.
+
+## Behavior
+
+- Handles both `twitter.com` and `x.com` status URLs.
+- Disabled by default; enable per guild with `/twitterembed toggle`.
+- URLs wrapped in `<angle brackets>` or `||spoilers||` are ignored.

--- a/app/cogs/twitterembed/twitterembed.py
+++ b/app/cogs/twitterembed/twitterembed.py
@@ -27,15 +27,42 @@ class TwitterEmbed(
             bot,
             "Twitter/X Embed Fix",
             [
-                EmbedFixCog.PatternReplacement(
-                    twitter_pattern,
-                    "twitter.com",
-                    "fxtwitter.com",
+                EmbedFixCog.Handler(
+                    "fxtwitter",
+                    "FxTwitter",
+                    "Uses fxtwitter.com",
+                    [
+                        EmbedFixCog.PatternReplacement(
+                            twitter_pattern, "twitter.com", "fxtwitter.com"
+                        ),
+                        EmbedFixCog.PatternReplacement(
+                            x_pattern, "x.com", "fxtwitter.com"
+                        ),
+                    ],
                 ),
-                EmbedFixCog.PatternReplacement(
-                    x_pattern,
-                    "x.com",
-                    "fxtwitter.com",
+                EmbedFixCog.Handler(
+                    "vxtwitter",
+                    "VxTwitter",
+                    "Uses vxtwitter.com / fixvx.com for x.com links",
+                    [
+                        EmbedFixCog.PatternReplacement(
+                            twitter_pattern, "twitter.com", "vxtwitter.com"
+                        ),
+                        EmbedFixCog.PatternReplacement(x_pattern, "x.com", "fixvx.com"),
+                    ],
+                ),
+                EmbedFixCog.Handler(
+                    "fixupx",
+                    "FixupX",
+                    "Uses fixupx.com",
+                    [
+                        EmbedFixCog.PatternReplacement(
+                            twitter_pattern, "twitter.com", "fixupx.com"
+                        ),
+                        EmbedFixCog.PatternReplacement(
+                            x_pattern, "x.com", "fixupx.com"
+                        ),
+                    ],
                 ),
             ],
             TwitterEmbedConfig,
@@ -60,6 +87,14 @@ class TwitterEmbed(
     @is_bot_owner_or_admin()
     async def toggle(self, interaction):
         await super().toggle(interaction)
+
+    @g.command(
+        name="handler",
+        description="Switch the Twitter/X embed handler for this server",
+    )
+    @is_bot_owner_or_admin()
+    async def handler(self, interaction):
+        await self._show_handler_select(interaction)
 
 
 async def setup(bot):

--- a/migrations/016_embedfix_handler_id.py
+++ b/migrations/016_embedfix_handler_id.py
@@ -1,0 +1,32 @@
+import os
+
+from dotenv import load_dotenv
+from playhouse.migrate import *
+
+load_dotenv()
+
+db = SqliteDatabase(os.getenv("SQLITE_DB"))
+
+migrator = SqliteMigrator(db)
+
+TABLES = [
+    "twitterembed_config",
+    "instaembed_config",
+    "tiktokembed_config",
+    "redditembed_config",
+    "facebookembed_config",
+]
+
+
+def run():
+    existing_tables = db.get_tables()
+    for table in TABLES:
+        if table not in existing_tables:
+            print(f"Table '{table}' does not exist, skipping.")
+            continue
+        existing_columns = [col.name for col in db.get_columns(table)]
+        if "handler_id" not in existing_columns:
+            migrate(migrator.add_column(table, "handler_id", CharField(default="")))
+            print(f"Added 'handler_id' column to {table}.")
+        else:
+            print(f"Column 'handler_id' already exists in {table}. No changes made.")


### PR DESCRIPTION
# Description

   - Adds a `/[cog] handler` slash command to Twitter/X, Instagram, TikTok, and Reddit embed fix cogs that presents a dropdown of available fixer services
   - Guild admins can switch handlers live (e.g. swap zzinstagram → ddinstagram if a service goes down) without any bot restart
   - Active handler is persisted per guild via a new `handler_id` column on each embed config table (migration 016)
   - Falls back to the first/default handler if none is set
