### PR TITLE
fix(redditfeed): prevent mass re-post spam after an OOM restart

### DIFF
--- a/app/cogs/redditfeed/redditfeed.py
+++ b/app/cogs/redditfeed/redditfeed.py
@@ -30,6 +30,13 @@ class RedditFeed(LancoCog, name="RedditFeed", description="Reddit feed polling")
     STATE_WINDOW_MINUTES = (
         120  # only check posts made within this window for state changes
     )
+    # Safety valve: a live subreddit yields 0-1 new posts per poll cycle. Seeing
+    # many "new" posts at once is the signature of a lost/stale baseline (fresh
+    # process, rolled-back DB, missing rows), not real activity. Above this count
+    # we do NOT post — we silently adopt the current feed as the new baseline.
+    # This makes the "is this post new?" decision fail closed instead of open,
+    # so a stale baseline can never turn into a mass re-post.
+    MAX_NEW_POSTS_PER_POLL = 10
 
     def __init__(self, bot: commands.Bot):
         super().__init__(bot)
@@ -114,6 +121,26 @@ class RedditFeed(LancoCog, name="RedditFeed", description="Reddit feed polling")
 
             new_count = sum(1 for s in submissions if s.id not in seen_ids)
             self.logger.info(f"[{sr}] {new_count} new post(s) to process")
+
+            # Safety valve: too many "new" posts at once means the baseline is
+            # lost/stale, not that the subreddit suddenly exploded. Adopt the
+            # current feed as the baseline (persist the high-water mark so future
+            # restarts stay quiet) and post nothing, rather than spamming days of
+            # old posts to every channel.
+            if new_count > self.MAX_NEW_POSTS_PER_POLL:
+                self.logger.warning(
+                    f"[{sr}] {new_count} new posts in one poll exceeds safety "
+                    f"threshold ({self.MAX_NEW_POSTS_PER_POLL}); adopting current "
+                    f"feed as baseline and skipping posting to avoid a re-post spam"
+                )
+                newest_ts = max((s.created_utc for s in submissions), default=None)
+                for s in submissions:
+                    seen_ids.add(s.id)
+                if newest_ts is not None:
+                    for config in configs:
+                        config.last_known_post_creation = newest_ts
+                        config.save()
+                continue
 
             for submission in submissions:
                 # Skip already seen posts — state changes handled by check_post_states

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,7 @@
-version: "3.7"
+# Format 2.4 (not 3.x): docker-compose (non-swarm) only honors mem_limit /
+# mem_reservation in the 2.x format. In 3.x these move under deploy.resources,
+# which `docker-compose up` ignores outside swarm.
+version: "2.4"
 
 services:
   app:
@@ -6,6 +9,11 @@ services:
     container_name: lanco-bot
     restart: unless-stopped
     env_file: .env.prod
+    # Hard cap so a memory spike/leak restarts THIS container cleanly instead of
+    # the host OOM killer reaping the process. 512m fits the bot's normal usage
+    # with headroom; raise it if `docker stats` shows it sitting near the limit.
+    mem_limit: 512m
+    mem_reservation: 256m
     volumes:
       - ./data:/app/data
       - ./logs:/app/logs


### PR DESCRIPTION
## Problem

An OOM restart made the bot re-post ~100 old r/lancaster posts to every feed channel. On a fresh process the dedup state seeded from disk was stale, so the whole 100-post fetch looked new and got posted.

## Changes

- **redditfeed:** if a single poll finds more than `MAX_NEW_POSTS_PER_POLL` (10) new posts, treat it as a lost baseline: post nothing, adopt the current feed as the baseline, and persist the high-water mark. Normal polls (0-1 new) are unaffected.
- **deploy:** cap the container at 512m so a spike restarts this container cleanly instead of the host OOM killer. Uses compose format 2.4 (v1.25 ignores the v3 form).

## Verified

- `poetry run test`: 15 passed.
- Fired correctly in prod (2026-07-24 22:59), suppressing an 81-post spam.

## Deploy

`mem_limit` needs a recreate: `docker-compose up -d --force-recreate app`