### PR TITLE
fix(redditfeed): detect posts removed by reddit admins

### DIFF
--- a/app/cogs/redditfeed/README.md
+++ b/app/cogs/redditfeed/README.md
@@ -40,6 +40,7 @@ Stop watching a subreddit in the current channel.
 
 - **Author deletions** are detected via `reddit.info()` and reflected near-instantly
 - **Moderator removals** are detected reliably and reflected within the state check interval
+- **Reddit admin takedowns** (content policy, legal, copyright) are detected via `removed_by_category` and shown with a **Removed by Reddit** status; the embed image is dropped along with the original content
 - **Edits** are best-effort — the Reddit API caches post data aggressively and edited state can take many minutes to propagate or may not propagate at all, particularly on low-traffic subreddits or new accounts. This is a known Reddit API limitation with no reliable workaround without streaming
 - The bot uses ID-based deduplication so posts held in a moderation queue will still be shared when they become visible
 - State changes are only tracked for posts within the last **30 minutes** of being created

--- a/app/cogs/redditfeed/models.py
+++ b/app/cogs/redditfeed/models.py
@@ -24,6 +24,7 @@ class RedditPost(BaseModel):
     spoiler = BooleanField()
     deleted = BooleanField(default=False)
     removed = BooleanField(default=False)
+    removed_by_reddit = BooleanField(default=False)
     edited = BooleanField(default=False)
     comment_count = IntegerField(null=True)
     score = IntegerField(null=True)

--- a/app/cogs/redditfeed/redditfeed.py
+++ b/app/cogs/redditfeed/redditfeed.py
@@ -38,6 +38,16 @@ class RedditFeed(LancoCog, name="RedditFeed", description="Reddit feed polling")
     # so a stale baseline can never turn into a mass re-post.
     MAX_NEW_POSTS_PER_POLL = 10
 
+    # removed_by_category values that mean Reddit itself (admins/AEO/legal)
+    # took the post down, as opposed to the author or a subreddit mod
+    REDDIT_REMOVAL_CATEGORIES = {
+        "reddit",
+        "anti_evil_ops",
+        "content_takedown",
+        "copyright_takedown",
+    }
+    MOD_REMOVAL_CATEGORIES = {"moderator", "automod_filtered", "community_ops"}
+
     def __init__(self, bot: commands.Bot):
         super().__init__(bot)
         self.bot.database.create_tables([RedditFeedConfig, RedditPost])
@@ -80,6 +90,22 @@ class RedditFeed(LancoCog, name="RedditFeed", description="Reddit feed polling")
             await self.update_post_states()
         except Exception as e:
             self.logger.error(f"Error checking post states: {e}")
+
+    def get_removal_state(self, submission: Submission) -> tuple[bool, bool, bool]:
+        """Classify a submission as (deleted, removed, removed_by_reddit).
+
+        removed_by_category is the authoritative signal; the selftext sentinels
+        are kept as a fallback since link posts have no selftext to compare.
+        Admin takedowns rewrite selftext to a policy notice rather than
+        "[removed]", so they are only detectable via removed_by_category.
+        """
+        category = getattr(submission, "removed_by_category", None)
+        removed_by_reddit = category in self.REDDIT_REMOVAL_CATEGORIES
+        deleted = category == "deleted" or submission.selftext == "[deleted]"
+        removed = category in self.MOD_REMOVAL_CATEGORIES or (
+            submission.selftext == "[removed]" and not removed_by_reddit and not deleted
+        )
+        return deleted, removed, removed_by_reddit
 
     async def get_new_posts(self):
         """Get new posts from watched subreddits and share them to the configured channels"""
@@ -163,8 +189,7 @@ class RedditFeed(LancoCog, name="RedditFeed", description="Reddit feed polling")
 
                 # New post — share to all configured channels
                 author = submission.author.name if submission.author else "[deleted]"
-                deleted = submission.selftext == "[deleted]"
-                removed = submission.selftext == "[removed]"
+                deleted, removed, removed_by_reddit = self.get_removal_state(submission)
                 edited = bool(submission.edited)
                 permalink = f"https://reddit.com{submission.permalink}"
 
@@ -202,6 +227,7 @@ class RedditFeed(LancoCog, name="RedditFeed", description="Reddit feed polling")
                         spoiler=submission.spoiler,
                         deleted=deleted,
                         removed=removed,
+                        removed_by_reddit=removed_by_reddit,
                         edited=False,  # always False on first insert; set True on update
                         comment_count=submission.num_comments,
                         score=submission.score,
@@ -234,6 +260,7 @@ class RedditFeed(LancoCog, name="RedditFeed", description="Reddit feed polling")
                 RedditPost.subreddit << active_subreddits,
                 RedditPost.deleted == False,
                 RedditPost.removed == False,
+                RedditPost.removed_by_reddit == False,
             )
         )
 
@@ -261,24 +288,26 @@ class RedditFeed(LancoCog, name="RedditFeed", description="Reddit feed polling")
                 if not submission:
                     continue
 
-                deleted = submission.selftext == "[deleted]"
-                removed = submission.selftext == "[removed]"
+                deleted, removed, removed_by_reddit = self.get_removal_state(submission)
                 edited = bool(submission.edited)
 
                 if (
                     post.deleted == deleted
                     and post.removed == removed
+                    and post.removed_by_reddit == removed_by_reddit
                     and post.edited == edited
                 ):
                     continue
 
                 self.logger.info(
-                    f"[{sr}] Post {post.post_id} state changed — "
-                    f"deleted={deleted} removed={removed} edited={edited}"
+                    f"[{sr}] Post {post.post_id} state changed - "
+                    f"deleted={deleted} removed={removed} "
+                    f"removed_by_reddit={removed_by_reddit} edited={edited}"
                 )
 
                 post.deleted = deleted
                 post.removed = removed
+                post.removed_by_reddit = removed_by_reddit
                 post.edited = edited
                 post.comment_count = submission.num_comments
                 post.score = submission.score
@@ -392,8 +421,7 @@ class RedditFeed(LancoCog, name="RedditFeed", description="Reddit feed polling")
         """Share or update a Reddit post in a channel."""
         permalink = f"https://reddit.com{submission.permalink}"
 
-        deleted = submission.selftext == "[deleted]"
-        removed = submission.selftext == "[removed]"
+        deleted, removed, removed_by_reddit = self.get_removal_state(submission)
 
         # Convert Reddit markdown to Discord-compatible markdown
         selftext = reddit_to_discord(submission.selftext)
@@ -412,7 +440,7 @@ class RedditFeed(LancoCog, name="RedditFeed", description="Reddit feed polling")
         icon = await self.get_subreddit_icon(submission.subreddit.display_name)
 
         color = discord.Color(0xFF0000)
-        if deleted or removed:
+        if deleted or removed or removed_by_reddit:
             color = discord.Color(0x808080)
 
         embed = discord.Embed(
@@ -438,9 +466,11 @@ class RedditFeed(LancoCog, name="RedditFeed", description="Reddit feed polling")
             ),
         )
 
-        # Status field — only shown when something has changed
+        # Status field, only shown when something has changed
         if deleted:
             embed.add_field(name="Status", value="Deleted")
+        elif removed_by_reddit:
+            embed.add_field(name="Status", value="Removed by Reddit")
         elif removed:
             embed.add_field(name="Status", value="Removed")
         elif submission.edited:
@@ -492,7 +522,7 @@ class RedditFeed(LancoCog, name="RedditFeed", description="Reddit feed polling")
                         image_url = item["s"]["u"]
                         break
 
-        if image_url and not deleted and not removed:
+        if image_url and not deleted and not removed and not removed_by_reddit:
             if nsfw:
                 image_path = await self.file_downloader.download_file(
                     image_url, self.cache_dir

--- a/migrations/019_reddit_feed_removed_by_reddit.py
+++ b/migrations/019_reddit_feed_removed_by_reddit.py
@@ -1,0 +1,25 @@
+import os
+
+from dotenv import load_dotenv
+from playhouse.migrate import *
+
+load_dotenv()
+
+table_name = "reddit_post"
+
+db = SqliteDatabase(os.getenv("SQLITE_DB"))
+
+migrator = SqliteMigrator(db)
+
+new_columns = {
+    "removed_by_reddit": BooleanField(default=False),
+}
+
+
+def run():
+    existing_columns = db.get_columns(table_name)
+    for column_name, field in new_columns.items():
+        if column_name not in [col.name for col in existing_columns]:
+            migrate(migrator.add_column(table_name, column_name, field))
+        else:
+            print(f"Column '{column_name}' already exists. No changes made.")


### PR DESCRIPTION
## Problem

A post shared to r/lancaster's feed channel was taken down by Reddit itself (content policy/legal), not the author or a mod. Admin/AEO takedowns rewrite `selftext` to a policy notice instead of the `[deleted]`/`[removed]` sentinels the state checker matched on, so the removal went undetected and the original post stayed visible in Discord indefinitely.

## Changes

- **redditfeed:** classify removal state from `removed_by_category` instead of raw `selftext` matching, distinguishing author deletions, mod removals, and reddit takedowns (content policy, legal, copyright, anti-evil-ops); selftext sentinels are kept as a fallback for link posts, which have no selftext
- **redditfeed:** reddit takedowns get their own **Removed by Reddit** status field and drop the embed image, same as other removal states
- **redditfeed:** new `removed_by_reddit` column on `reddit_post`; the state checker now skips posts already taken down, same as it does for deleted/removed ones
- **migrations:** `019_reddit_feed_removed_by_reddit.py` adds the column

## Verified

- `poetry run test`: 15 passed
- Checked the actual removed post (r/lancaster 1v8dgeo) via the bot's live API credentials: classifies as `removed_by_reddit=True`
- Synthetic cases for author-delete, mod-removal, automod-filtered, reddit/AEO, copyright, normal post, and no-category fallbacks all classify as expected
- pre-commit (black, isort) passed on commit

## Note

The message from the original incident won't be retroactively fixed, since the state checker only re-checks posts created within the last 2 hours. That one needs a manual edit/delete.