### PR TITLE
fix(chatbot): use tracked message check instead of embed heuristic for replies

### DIFF
--- a/app/cogs/chatbot/chatbot.py
+++ b/app/cogs/chatbot/chatbot.py
@@ -12,6 +12,7 @@ from PIL import Image
 from pydantic_ai import Agent, BinaryContent, ImageUrl
 from pydantic_ai.messages import ModelMessage
 from utils.ai_utils import run_agent
+from utils.tracked_message import is_message_tracked
 
 _MENTION_RE = re.compile(r"<@!?(\d+)>")
 
@@ -216,7 +217,7 @@ class ChatBot(
                 message.reference.message_id
             )
             if referenced_msg.author.id == self.bot.user.id:
-                if referenced_msg.embeds:
+                if is_message_tracked(referenced_msg.id):
                     return
                 is_reply = True
             elif referenced_msg.author.bot:


### PR DESCRIPTION
## Problem

Chatbot decided whether a reply should trigger a conversation by checking if the referenced bot message had embeds. In channels without embed permissions, utility responses (e.g. `.topic`) are sent as plain text, so the embed check failed to recognize them as non-chat responses and the bot engaged in conversation with whoever replied.

## Changes

- **chatbot:** replace the `referenced_msg.embeds` check with `is_message_tracked()`, which looks up the `tracked_messages` table already populated by `@track_message_ids()` on `.topic`, `.vibecheck`, `.eli5`, `.chime`, and other commands, so the check works regardless of the channel's embed permissions

## Verified

- pre-commit (black, isort) passed on commit