### PR TITLE
fix(chatbot): restore embed check alongside tracked message check

### DIFF
--- a/app/cogs/chatbot/chatbot.py
+++ b/app/cogs/chatbot/chatbot.py
@@ -232,7 +232,7 @@ class ChatBot(
                 message.reference.message_id
             )
             if referenced_msg.author.id == self.bot.user.id:
-                if is_message_tracked(referenced_msg.id):
+                if referenced_msg.embeds or is_message_tracked(referenced_msg.id):
                     return
                 is_reply = True
             elif referenced_msg.author.bot:


### PR DESCRIPTION
## Problem

Regression from #160. Swapping the `referenced_msg.embeds` check for `is_message_tracked()` dropped coverage for cogs that never track their posts, so replying to a feed embed (incidents, rssfeed, redditfeed, youtube) engages the chatbot. It did not before #160.

## Changes

- **chatbot:** check `referenced_msg.embeds` alongside `is_message_tracked()` rather than in place of it

## Verified

- `poetry run test`: 15 passed
