### PR TITLE
fix(core): replace the sqlite write queue with wal and a busy timeout

### DIFF
--- a/app/cogs/captcha/captcha.py
+++ b/app/cogs/captcha/captcha.py
@@ -186,18 +186,21 @@ class CaptchaCog(
 
     async def on_game_end(self, session: CaptchaSession):
         if len(session.members) > 1:
-            with self.bot.database.atomic():
-                for user_id, score in session.members.items():
-                    RoundGameResult.create(
-                        game_name=self.GAME_NAME,
-                        game_id=session.game_id,
-                        guild_id=session.channel.guild.id,
-                        user_id=user_id,
-                        mode=session.mode.name,
-                        score=score,
-                        rounds_played=len(session.rounds),
-                        scoring_version=self.SCORING_VERSION,
-                    )
+            RoundGameResult.insert_many(
+                [
+                    {
+                        "game_name": self.GAME_NAME,
+                        "game_id": session.game_id,
+                        "guild_id": session.channel.guild.id,
+                        "user_id": user_id,
+                        "mode": session.mode.name,
+                        "score": score,
+                        "rounds_played": len(session.rounds),
+                        "scoring_version": self.SCORING_VERSION,
+                    }
+                    for user_id, score in session.members.items()
+                ]
+            ).execute()
             self.logger.info(
                 f"Recorded captcha results for game {session.game_id} — {len(session.members)} players"
             )

--- a/app/cogs/captcha/captcha.py
+++ b/app/cogs/captcha/captcha.py
@@ -189,14 +189,14 @@ class CaptchaCog(
             RoundGameResult.insert_many(
                 [
                     {
-                        "game_name": self.GAME_NAME,
-                        "game_id": session.game_id,
-                        "guild_id": session.channel.guild.id,
-                        "user_id": user_id,
-                        "mode": session.mode.name,
-                        "score": score,
-                        "rounds_played": len(session.rounds),
-                        "scoring_version": self.SCORING_VERSION,
+                        RoundGameResult.game_name: self.GAME_NAME,
+                        RoundGameResult.game_id: session.game_id,
+                        RoundGameResult.guild_id: session.channel.guild.id,
+                        RoundGameResult.user_id: user_id,
+                        RoundGameResult.mode: session.mode.name,
+                        RoundGameResult.score: score,
+                        RoundGameResult.rounds_played: len(session.rounds),
+                        RoundGameResult.scoring_version: self.SCORING_VERSION,
                     }
                     for user_id, score in session.members.items()
                 ]

--- a/app/cogs/geoguesser/geoguesser.py
+++ b/app/cogs/geoguesser/geoguesser.py
@@ -786,7 +786,6 @@ class GeoGuesser(
                 import concurrent.futures
 
                 import googlemaps
-                from peewee import SqliteDatabase
 
                 api_key = os.getenv("GMAPS_API_KEY")
                 workers = min(count, 5)
@@ -809,26 +808,25 @@ class GeoGuesser(
                 with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as pool:
                     locations = list(pool.map(generate_one, range(count)))
 
-                thread_db = SqliteDatabase(os.getenv("SQLITE_DB"))
-                thread_db.connect()
-                try:
-                    with LocationModel.bind_ctx(thread_db):
-                        with thread_db.atomic():
-                            LocationModel.delete().where(
-                                LocationModel.mode == mode.name
-                            ).execute()
-                            for location in locations:
-                                LocationModel.create(
-                                    mode=mode.name,
-                                    initial_lat=location.initial_location.lat,
-                                    initial_lng=location.initial_location.lng,
-                                    road_lat=location.road_coords.lat,
-                                    road_lng=location.road_coords.lng,
-                                    label=location.label,
-                                )
-                    return locations
-                finally:
-                    thread_db.close()
+                # Write through the shared database rather than a second connection,
+                # so these writes are serialized with the rest of the bot instead of
+                # contending for the file lock. insert_many keeps it to two statements
+                # since SqliteQueueDatabase does not support atomic().
+                LocationModel.delete().where(LocationModel.mode == mode.name).execute()
+                LocationModel.insert_many(
+                    [
+                        {
+                            "mode": mode.name,
+                            "initial_lat": location.initial_location.lat,
+                            "initial_lng": location.initial_location.lng,
+                            "road_lat": location.road_coords.lat,
+                            "road_lng": location.road_coords.lng,
+                            "label": location.label,
+                        }
+                        for location in locations
+                    ]
+                ).execute()
+                return locations
 
             task = asyncio.create_task(asyncio.to_thread(generate_and_save))
 

--- a/app/cogs/geoguesser/geoguesser.py
+++ b/app/cogs/geoguesser/geoguesser.py
@@ -220,18 +220,21 @@ class GeoGuesser(
 
     async def on_game_end(self, session: GameSession):
         if len(session.members) > 1:
-            with self.bot.database.atomic():
-                for user_id, score in session.members.items():
-                    RoundGameResult.create(
-                        game_name=self.GAME_NAME,
-                        game_id=session.game_id,
-                        guild_id=session.channel.guild.id,
-                        user_id=user_id,
-                        mode=session.mode.name,
-                        score=score,
-                        rounds_played=len(session.rounds),
-                        scoring_version=self.SCORING_VERSION,
-                    )
+            RoundGameResult.insert_many(
+                [
+                    {
+                        "game_name": self.GAME_NAME,
+                        "game_id": session.game_id,
+                        "guild_id": session.channel.guild.id,
+                        "user_id": user_id,
+                        "mode": session.mode.name,
+                        "score": score,
+                        "rounds_played": len(session.rounds),
+                        "scoring_version": self.SCORING_VERSION,
+                    }
+                    for user_id, score in session.members.items()
+                ]
+            ).execute()
             self.logger.info(
                 f"Recorded results for game {session.game_id} — {len(session.members)} players"
             )
@@ -725,9 +728,10 @@ class GeoGuesser(
     )
     @is_bot_owner()
     async def seedleaderboard(self, interaction: discord.Interaction):
-        import datetime
         import random
         import uuid
+
+        from peewee import chunked
 
         members = [m for m in interaction.guild.members if not m.bot]
         if not members:
@@ -735,18 +739,22 @@ class GeoGuesser(
             return
 
         game_id = uuid.uuid4()
-        with self.bot.database.atomic():
-            for member in members:
-                RoundGameResult.create(
-                    game_name=self.GAME_NAME,
-                    game_id=game_id,
-                    guild_id=interaction.guild.id,
-                    user_id=member.id,
-                    mode=self.city_mode.name,
-                    score=round(random.uniform(10, 500), 1),
-                    rounds_played=10,
-                    scoring_version=self.SCORING_VERSION,
-                )
+        rows = [
+            {
+                "game_name": self.GAME_NAME,
+                "game_id": game_id,
+                "guild_id": interaction.guild.id,
+                "user_id": member.id,
+                "mode": self.city_mode.name,
+                "score": round(random.uniform(10, 500), 1),
+                "rounds_played": 10,
+                "scoring_version": self.SCORING_VERSION,
+            }
+            for member in members
+        ]
+        # chunked so a large guild cannot blow past SQLite's bound-parameter limit
+        for batch in chunked(rows, 100):
+            RoundGameResult.insert_many(batch).execute()
 
         await interaction.response.send_message(
             f"Seeded dummy results for {len(members)} members.", ephemeral=True

--- a/app/cogs/geoguesser/geoguesser.py
+++ b/app/cogs/geoguesser/geoguesser.py
@@ -223,14 +223,14 @@ class GeoGuesser(
             RoundGameResult.insert_many(
                 [
                     {
-                        "game_name": self.GAME_NAME,
-                        "game_id": session.game_id,
-                        "guild_id": session.channel.guild.id,
-                        "user_id": user_id,
-                        "mode": session.mode.name,
-                        "score": score,
-                        "rounds_played": len(session.rounds),
-                        "scoring_version": self.SCORING_VERSION,
+                        RoundGameResult.game_name: self.GAME_NAME,
+                        RoundGameResult.game_id: session.game_id,
+                        RoundGameResult.guild_id: session.channel.guild.id,
+                        RoundGameResult.user_id: user_id,
+                        RoundGameResult.mode: session.mode.name,
+                        RoundGameResult.score: score,
+                        RoundGameResult.rounds_played: len(session.rounds),
+                        RoundGameResult.scoring_version: self.SCORING_VERSION,
                     }
                     for user_id, score in session.members.items()
                 ]
@@ -741,14 +741,14 @@ class GeoGuesser(
         game_id = uuid.uuid4()
         rows = [
             {
-                "game_name": self.GAME_NAME,
-                "game_id": game_id,
-                "guild_id": interaction.guild.id,
-                "user_id": member.id,
-                "mode": self.city_mode.name,
-                "score": round(random.uniform(10, 500), 1),
-                "rounds_played": 10,
-                "scoring_version": self.SCORING_VERSION,
+                RoundGameResult.game_name: self.GAME_NAME,
+                RoundGameResult.game_id: game_id,
+                RoundGameResult.guild_id: interaction.guild.id,
+                RoundGameResult.user_id: member.id,
+                RoundGameResult.mode: self.city_mode.name,
+                RoundGameResult.score: round(random.uniform(10, 500), 1),
+                RoundGameResult.rounds_played: 10,
+                RoundGameResult.scoring_version: self.SCORING_VERSION,
             }
             for member in members
         ]
@@ -824,12 +824,12 @@ class GeoGuesser(
                 LocationModel.insert_many(
                     [
                         {
-                            "mode": mode.name,
-                            "initial_lat": location.initial_location.lat,
-                            "initial_lng": location.initial_location.lng,
-                            "road_lat": location.road_coords.lat,
-                            "road_lng": location.road_coords.lng,
-                            "label": location.label,
+                            LocationModel.mode: mode.name,
+                            LocationModel.initial_lat: location.initial_location.lat,
+                            LocationModel.initial_lng: location.initial_location.lng,
+                            LocationModel.road_lat: location.road_coords.lat,
+                            LocationModel.road_lng: location.road_coords.lng,
+                            LocationModel.label: location.label,
                         }
                         for location in locations
                     ]

--- a/app/cogs/geoguesser/geoguesser.py
+++ b/app/cogs/geoguesser/geoguesser.py
@@ -818,8 +818,8 @@ class GeoGuesser(
 
                 # Write through the shared database rather than a second connection,
                 # so these writes are serialized with the rest of the bot instead of
-                # contending for the file lock. insert_many keeps it to two statements
-                # since SqliteQueueDatabase does not support atomic().
+                # contending for the file lock. insert_many keeps the replacement to
+                # two statements instead of one per location.
                 LocationModel.delete().where(LocationModel.mode == mode.name).execute()
                 LocationModel.insert_many(
                     [

--- a/app/cogs/redditfeed/redditfeed.py
+++ b/app/cogs/redditfeed/redditfeed.py
@@ -61,8 +61,8 @@ class RedditFeed(LancoCog, name="RedditFeed", description="Reddit feed polling")
         )  # 24 hours
         self.cache_dir = os.path.join(self.get_cog_data_directory(), "Cache")
         self.file_downloader = FileDownloader()
-        # In-memory seen set so SqliteQueueDatabase write-queue latency can't
-        # cause re-posts between poll cycles. Seeded from DB on first poll.
+        # In-memory seen set guarding against re-posts between poll cycles.
+        # Seeded from DB on first poll.
         self._seen_ids: dict[str, set[str]] = {}  # subreddit -> set of post_ids
         self._seen_ids_loaded: set[str] = set()  # subreddits whose DB rows are loaded
 

--- a/app/main.py
+++ b/app/main.py
@@ -17,7 +17,6 @@ from discord.ext import commands
 from dotenv import load_dotenv
 from logtail import LogtailHandler
 from peewee import *
-from playhouse.sqliteq import SqliteQueueDatabase
 from utils.command_utils import is_bot_owner
 from utils.router import ImageRouter, Intent
 from watchfiles import Change, awatch
@@ -309,15 +308,18 @@ def init_db() -> Database:
         db_dir = os.path.dirname(sqlite_path)
         if db_dir and not os.path.exists(db_dir):
             os.makedirs(db_dir)
-        db = SqliteQueueDatabase(
+        # WAL plus a busy timeout is what serializes SQLite writers. A write
+        # queue is not used: it executes BEGIN on its writer thread's connection
+        # while COMMIT runs on the caller's, so transactions (including the one
+        # inside get_or_create) never commit and leak the write lock.
+        db = SqliteDatabase(
             sqlite_path,
             pragmas={
                 "journal_mode": "wal",
                 "cache_size": -1024 * 32,
                 "foreign_keys": 1,
+                "busy_timeout": 5000,
             },
-            thread_safe=True,
-            timeout=5,
         )
 
     elif db_type == DatabaseType.MYSQL:

--- a/app/main.py
+++ b/app/main.py
@@ -798,7 +798,7 @@ async def main():
         if config.prefix:
             _prefix_cache[config.guild_id] = config.prefix
 
-    db_backup = DatabaseBackup(database=database)
+    db_backup = DatabaseBackup()
     await bot.load_cogs()
     async with bot:
         db_backup.start()

--- a/app/utils/db_backup.py
+++ b/app/utils/db_backup.py
@@ -2,14 +2,13 @@ import asyncio
 import datetime
 import logging
 import os
-import shutil
+import sqlite3
 
 logger = logging.getLogger(__name__)
 
 
 class DatabaseBackup:
-    def __init__(self, database=None):
-        self.database = database
+    def __init__(self):
         self.backup_dir = os.getenv("DATABASE_BACKUP_DIRECTORY", "db_backups")
         self.backup_filename = os.getenv("DATABASE_BACKUP_FILENAME", "db_backup_{}.db")
         self.backup_interval = int(os.getenv("DATABASE_BACKUP_INTERVAL", 86400))
@@ -49,13 +48,33 @@ class DatabaseBackup:
 
         logger.info(f"Backing up database to {dest}")
         try:
-            if self.database:
-                self.database.execute_sql("PRAGMA wal_checkpoint(TRUNCATE)")
-            await asyncio.to_thread(shutil.copy2, self.database_path, dest)
-            logger.info(f"Database backed up to {dest}")
+            await asyncio.to_thread(self._snapshot, dest)
+            size = os.path.getsize(dest)
+            logger.info(f"Database backed up to {dest} ({size} bytes)")
             await asyncio.to_thread(self._prune_old_backups)
-        except Exception as e:
-            logger.error(f"Database backup failed: {e}")
+        except Exception:
+            logger.exception("Database backup failed")
+
+    def _snapshot(self, dest: str) -> None:
+        """Copy the database using SQLite's online backup API.
+
+        A plain file copy is not safe in WAL mode: recent commits live in the
+        -wal sidecar, which is not copied. The previous approach checkpointed
+        first, but ignored the result, and a checkpoint that reports busy leaves
+        those commits only in the WAL, producing a backup that silently misses
+        them. The backup API snapshots the database consistently, including
+        whatever is still in the WAL, without having to block writers.
+        """
+        source = sqlite3.connect(f"file:{self.database_path}?mode=ro", uri=True)
+        try:
+            target = sqlite3.connect(dest)
+            try:
+                with target:
+                    source.backup(target)
+            finally:
+                target.close()
+        finally:
+            source.close()
 
     def _prune_old_backups(self):
         backups = sorted(

--- a/tests/test_db_backup.py
+++ b/tests/test_db_backup.py
@@ -1,0 +1,143 @@
+"""Tests for DatabaseBackup.
+
+The behaviour that matters here is WAL-awareness. In WAL mode, commits live in
+the -wal sidecar until a checkpoint moves them into the main database file, so
+copying the file alone can produce a backup that is missing recent commits, or
+that has no usable content at all. These tests pin the snapshot to the logical
+database rather than the file on disk.
+"""
+
+import os
+import sqlite3
+
+import pytest
+from utils.db_backup import DatabaseBackup
+
+
+@pytest.fixture
+def wal_db(tmp_path):
+    """A WAL database with commits deliberately left uncheckpointed."""
+    path = str(tmp_path / "live.db")
+
+    conn = sqlite3.connect(path)
+    conn.execute("PRAGMA journal_mode=wal")
+    conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, val TEXT)")
+    conn.commit()
+    conn.executemany(
+        "INSERT INTO t (val) VALUES (?)", [(f"row{i}",) for i in range(500)]
+    )
+    conn.commit()
+
+    # A second connection holding a read transaction prevents checkpointing,
+    # which is the state a busy checkpoint leaves behind in production.
+    blocker = sqlite3.connect(path)
+    blocker.execute("BEGIN")
+    blocker.execute("SELECT COUNT(*) FROM t").fetchone()
+
+    conn.executemany(
+        "INSERT INTO t (val) VALUES (?)", [(f"late{i}",) for i in range(200)]
+    )
+    conn.commit()
+
+    yield path, conn
+
+    blocker.close()
+    conn.close()
+
+
+def _backup_for(path, tmp_path, monkeypatch):
+    monkeypatch.setenv("SQLITE_DB", path)
+    monkeypatch.setenv("DATABASE_BACKUP_DIRECTORY", str(tmp_path / "backups"))
+    return DatabaseBackup()
+
+
+def test_checkpoint_is_blocked_in_this_scenario(wal_db):
+    """Guard the premise: without this, the other tests prove nothing."""
+    path, conn = wal_db
+    busy, _log, _checkpointed = conn.execute(
+        "PRAGMA wal_checkpoint(TRUNCATE)"
+    ).fetchone()
+    assert busy == 1, "expected a blocked checkpoint for these tests to be meaningful"
+
+
+def test_snapshot_captures_wal_resident_commits(wal_db, tmp_path, monkeypatch):
+    path, conn = wal_db
+    expected = conn.execute("SELECT COUNT(*) FROM t").fetchone()[0]
+
+    dest = str(tmp_path / "backup.db")
+    _backup_for(path, tmp_path, monkeypatch)._snapshot(dest)
+
+    restored = sqlite3.connect(dest)
+    try:
+        assert restored.execute("SELECT COUNT(*) FROM t").fetchone()[0] == expected
+    finally:
+        restored.close()
+
+
+def test_snapshot_beats_a_plain_file_copy(wal_db, tmp_path, monkeypatch):
+    """A file copy of the same database is incomplete or unusable."""
+    import shutil
+
+    path, conn = wal_db
+    expected = conn.execute("SELECT COUNT(*) FROM t").fetchone()[0]
+
+    copied = str(tmp_path / "copied.db")
+    shutil.copy2(path, copied)
+    try:
+        copy_rows = (
+            sqlite3.connect(copied).execute("SELECT COUNT(*) FROM t").fetchone()[0]
+        )
+    except sqlite3.DatabaseError:
+        copy_rows = None  # the copy has no usable table at all
+
+    assert copy_rows != expected, (
+        "a plain file copy unexpectedly captured everything, so this scenario no "
+        "longer reproduces the failure the backup API exists to avoid"
+    )
+
+
+def test_snapshot_preserves_content_not_just_row_count(wal_db, tmp_path, monkeypatch):
+    path, conn = wal_db
+    dest = str(tmp_path / "backup.db")
+    _backup_for(path, tmp_path, monkeypatch)._snapshot(dest)
+
+    restored = sqlite3.connect(dest)
+    try:
+        assert restored.execute(
+            "SELECT val FROM t WHERE val = 'late199'"
+        ).fetchone() == ("late199",)
+        assert restored.execute("SELECT val FROM t WHERE val = 'row0'").fetchone() == (
+            "row0",
+        )
+    finally:
+        restored.close()
+
+
+@pytest.mark.asyncio
+async def test_backup_writes_a_file_and_prunes(wal_db, tmp_path, monkeypatch):
+    path, _conn = wal_db
+    monkeypatch.setenv("DATABASE_BACKUP_RETENTION", "2")
+    backup = _backup_for(path, tmp_path, monkeypatch)
+    os.makedirs(backup.backup_dir, exist_ok=True)
+
+    # distinct filenames, since the real name is timestamped to the second
+    for i in range(4):
+        backup.backup_filename = f"db_backup_{i}_{{}}.db"
+        await backup.backup()
+
+    remaining = [f for f in os.listdir(backup.backup_dir) if f.endswith(".db")]
+    assert len(remaining) == 2, remaining
+
+
+@pytest.mark.asyncio
+async def test_backup_failure_does_not_raise(tmp_path, monkeypatch):
+    """A failing backup is logged, never propagated into the bot's task loop."""
+    monkeypatch.setenv("SQLITE_DB", str(tmp_path / "does_not_exist.db"))
+    monkeypatch.setenv("DATABASE_BACKUP_DIRECTORY", str(tmp_path / "backups"))
+    backup = DatabaseBackup()
+    os.makedirs(backup.backup_dir, exist_ok=True)
+
+    monkeypatch.setattr(
+        backup, "_snapshot", lambda dest: (_ for _ in ()).throw(RuntimeError("boom"))
+    )
+    await backup.backup()  # must not raise


### PR DESCRIPTION
## Problem

`SqliteQueueDatabase` executes `BEGIN` and the write on its writer thread's connection but calls `COMMIT` on the caller's, so a transaction never commits. `get_or_create` opens one on its create branch, so the first new row in a process is silently discarded, nothing raises, and the open transaction holds the write lock until the process restarts, failing every subsequent write with `database is locked`. Prod is latent rather than broken, since its create branch rarely runs; dev reproduces it on any new custom command.

## Changes

- **core:** use `SqliteDatabase` with WAL and `busy_timeout=5000`, which is what actually serializes SQLite writers
- **core:** snapshot backups with SQLite's online backup API, since a file copy in WAL mode misses commits still in the `-wal`
- **captcha, geoguesser:** record game results with `insert_many` instead of `atomic()`, which the queue backend rejects outright
- **geoguesser:** write generated locations through the shared connection instead of opening a second one

## Verified

- `poetry run test`: 21 passed, including 6 new backup tests that fail against the old file-copy path
- 16 concurrent writers against a migrated copy of the prod database: 347 cycles/sec, write lock never blocked
- dev: custom command persists across a restart, confirmed as a row on disk
