### PR TITLE
refactor(migrations): apply schema changes through shared idempotent helpers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ LancoBot is a modular Discord bot (Python / discord.py) built around a **cog sys
 
 **`app/utils/command_utils.py`** — Permission decorators (`is_bot_owner_or_admin`, etc.) used across cogs.
 
-**`migrations/`** — Sequential numbered migration scripts run via `poetry run migrate`. Use Peewee's `SqliteMigrator` / `MySQLMigrator` depending on `DB_TYPE`.
+**`migrations/`** — Sequential numbered migration scripts run via `poetry run migrate`. Each file exposes a single `upgrade(ctx)` function and makes every change through the idempotent helpers on the `MigrationContext` in `migrations/helpers.py`, which owns the connection and picks `SqliteMigrator` / `MySQLMigrator` based on `DB_TYPE`. Applied filenames are tracked in `schema_migrations`. See `migrations/README.md` for the contract.
 
 **`tests/`** — Core bot test suite using pytest + dpytest. Run with `poetry run test`.
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -48,7 +48,7 @@ Pieces a cog author touches:
 
 **`app/utils/command_utils.py`** - Permission decorators (`is_bot_owner_or_admin`, etc.) used across cogs.
 
-**`migrations/`** - Sequential numbered migration scripts run via `poetry run migrate`. Needed only when changing an existing model's schema; new tables are created by the cog itself.
+**`migrations/`** - Sequential numbered migration scripts run via `poetry run migrate`. Needed only when changing an existing model's schema; new tables are created by the cog itself. Each exposes an `upgrade(ctx)` function and makes its changes through the shared helpers in `migrations/helpers.py`; see `migrations/README.md`.
 
 **`tests/`** - Core bot test suite using pytest + dpytest. Run with `poetry run test`.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,4 +39,7 @@ COPY migrate.py .
 COPY migrations/ migrations/
 COPY pyproject.toml .
 
-CMD ["sh", "-c", "python migrate.py && python app/main.py"]
+# exec replaces the shell, so the bot is PID 1 and receives SIGTERM from
+# `docker stop`. Without it the shell stays PID 1, never forwards the signal,
+# and the bot is SIGKILLed after the grace period.
+CMD ["sh", "-c", "python migrate.py && exec python app/main.py"]

--- a/app/main.py
+++ b/app/main.py
@@ -3,6 +3,7 @@ import datetime
 import logging
 import os
 import shutil
+import signal
 import sys
 from dataclasses import dataclass
 from enum import Enum, auto
@@ -788,6 +789,33 @@ async def global_block_check(ctx):
     return True
 
 
+def _install_shutdown_handlers() -> None:
+    """Close the bot on SIGTERM so `docker stop` is a graceful shutdown.
+
+    Without this, Python's default disposition kills the process outright: the
+    gateway connection is never closed, and an in-flight database backup is
+    abandoned partway through. Closing the bot instead returns from
+    `bot.start()` and unwinds normally.
+
+    `add_signal_handler` is POSIX only, so on Windows this is a no-op and dev
+    keeps relying on KeyboardInterrupt.
+    """
+    loop = asyncio.get_running_loop()
+
+    def shutdown(signame: str) -> None:
+        logger.info(f"Received {signame}, shutting down")
+        asyncio.create_task(bot.close())
+
+    for signame in ("SIGTERM", "SIGINT"):
+        sig = getattr(signal, signame, None)
+        if sig is None:
+            continue
+        try:
+            loop.add_signal_handler(sig, shutdown, signame)
+        except NotImplementedError:
+            logger.debug(f"{signame} handler unavailable on this platform")
+
+
 async def main():
     from utils.config import GuildConfig
     from utils.db_backup import DatabaseBackup
@@ -801,9 +829,12 @@ async def main():
     db_backup = DatabaseBackup()
     await bot.load_cogs()
     async with bot:
+        _install_shutdown_handlers()
         db_backup.start()
-        await bot.start(os.getenv("DISCORD_TOKEN"))
-        db_backup.stop()
+        try:
+            await bot.start(os.getenv("DISCORD_TOKEN"))
+        finally:
+            db_backup.stop()
 
 
 if __name__ == "__main__":

--- a/app/utils/db_backup.py
+++ b/app/utils/db_backup.py
@@ -7,6 +7,45 @@ import sqlite3
 logger = logging.getLogger(__name__)
 
 
+def snapshot(database_path: str, dest: str) -> None:
+    """Copy a database using SQLite's online backup API.
+
+    A plain file copy is not safe in WAL mode: recent commits live in the
+    -wal sidecar, which is not copied. The previous approach checkpointed
+    first, but ignored the result, and a checkpoint that reports busy leaves
+    those commits only in the WAL, producing a backup that silently misses
+    them. The backup API snapshots the database consistently, including
+    whatever is still in the WAL, without having to block writers.
+
+    Shared with the migration runner, which snapshots before applying anything.
+    """
+    source = sqlite3.connect(f"file:{database_path}?mode=ro", uri=True)
+    try:
+        target = sqlite3.connect(dest)
+        try:
+            with target:
+                source.backup(target)
+        finally:
+            target.close()
+    finally:
+        source.close()
+
+
+def prune(directory: str, keep: int) -> None:
+    """Delete all but the newest ``keep`` .db files in ``directory``."""
+    backups = sorted(
+        [
+            os.path.join(directory, f)
+            for f in os.listdir(directory)
+            if f.endswith(".db")
+        ],
+        key=os.path.getmtime,
+    )
+    for path in backups[: max(0, len(backups) - keep)]:
+        os.remove(path)
+        logger.info(f"Pruned old backup: {path}")
+
+
 class DatabaseBackup:
     def __init__(self):
         self.backup_dir = os.getenv("DATABASE_BACKUP_DIRECTORY", "db_backups")
@@ -56,36 +95,7 @@ class DatabaseBackup:
             logger.exception("Database backup failed")
 
     def _snapshot(self, dest: str) -> None:
-        """Copy the database using SQLite's online backup API.
-
-        A plain file copy is not safe in WAL mode: recent commits live in the
-        -wal sidecar, which is not copied. The previous approach checkpointed
-        first, but ignored the result, and a checkpoint that reports busy leaves
-        those commits only in the WAL, producing a backup that silently misses
-        them. The backup API snapshots the database consistently, including
-        whatever is still in the WAL, without having to block writers.
-        """
-        source = sqlite3.connect(f"file:{self.database_path}?mode=ro", uri=True)
-        try:
-            target = sqlite3.connect(dest)
-            try:
-                with target:
-                    source.backup(target)
-            finally:
-                target.close()
-        finally:
-            source.close()
+        snapshot(self.database_path, dest)
 
     def _prune_old_backups(self):
-        backups = sorted(
-            [
-                os.path.join(self.backup_dir, f)
-                for f in os.listdir(self.backup_dir)
-                if f.endswith(".db")
-            ],
-            key=os.path.getmtime,
-        )
-        to_delete = backups[: max(0, len(backups) - self.backup_retention)]
-        for path in to_delete:
-            os.remove(path)
-            logger.info(f"Pruned old backup: {path}")
+        prune(self.backup_dir, self.backup_retention)

--- a/migrate.py
+++ b/migrate.py
@@ -1,18 +1,39 @@
-# migrate.py
+"""Applies pending migrations from ``migrations/``.
 
+Each migration runs exactly once. Applied names are recorded in the
+``schema_migrations`` table, and the schema change plus that bookkeeping row
+share a transaction, so a failed migration leaves nothing behind and is
+retried on the next run. (SQLite makes DDL transactional; MySQL commits
+implicitly on DDL, so there the rollback guarantee is best effort.)
+
+Usage:
+    python migrate.py             apply pending migrations
+    python migrate.py --status    list applied and pending migrations
+"""
+
+import argparse
 import datetime
 import importlib.util
+import logging
 import os
+import re
+import sys
 
-from dotenv import load_dotenv
-from peewee import *
+from peewee import CharField, DateTimeField, Model
 
-load_dotenv()
+ROOT = os.path.dirname(os.path.abspath(__file__))
 
-MIGRATIONS_DIR = "migrations"
+# Migrations import migrations.helpers by name, so the project root has to be
+# importable no matter which directory this was invoked from.
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
 
-_db_path = os.getenv("SQLITE_DB", "data/lancobot.db")
-_db = SqliteDatabase(_db_path)
+from migrations.helpers import MigrationContext, create_database  # noqa: E402
+
+MIGRATIONS_DIR = os.path.join(ROOT, "migrations")
+MIGRATION_PATTERN = re.compile(r"^\d{3}_\w+\.py$")
+
+logger = logging.getLogger("migrate")
 
 
 class SchemaMigration(Model):
@@ -20,43 +41,92 @@ class SchemaMigration(Model):
     applied_at = DateTimeField(default=datetime.datetime.now)
 
     class Meta:
-        database = _db
         table_name = "schema_migrations"
 
 
-def _ensure_tracking_table():
-    _db.connect(reuse_if_open=True)
-    _db.create_tables([SchemaMigration], safe=True)
+def _discover() -> list:
+    """Return migration filenames in the order they must be applied."""
+    return sorted(f for f in os.listdir(MIGRATIONS_DIR) if MIGRATION_PATTERN.match(f))
 
 
-def _applied_migrations() -> set:
+def _load(filename: str):
+    path = os.path.join(MIGRATIONS_DIR, filename)
+    module_name = f"migrations.{filename[:-3]}"
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+
+    if not hasattr(module, "upgrade"):
+        raise AttributeError(f"{filename} does not define an upgrade(ctx) function")
+    return module
+
+
+def _summary(module) -> str:
+    """First line of the migration's docstring, for log output."""
+    doc = (module.__doc__ or "").strip().splitlines()
+    return f": {doc[0]}" if doc else ""
+
+
+def _connect():
+    db = create_database()
+    db.connect(reuse_if_open=True)
+    SchemaMigration.bind(db)
+    db.create_tables([SchemaMigration])
+    return db
+
+
+def _applied() -> set:
     return {row.name for row in SchemaMigration.select()}
 
 
-def _run_migration_script(script_path):
-    spec = importlib.util.spec_from_file_location("migration", script_path)
-    migration = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(migration)
-    migration.run()
+def run_migrations() -> None:
+    db = _connect()
+    try:
+        applied = _applied()
+        pending = [name for name in _discover() if name not in applied]
+
+        if not pending:
+            logger.info("No pending migrations.")
+            return
+
+        ctx = MigrationContext(db)
+        for name in pending:
+            module = _load(name)
+            logger.info("Applying %s%s", name, _summary(module))
+            with db.atomic():
+                module.upgrade(ctx)
+                SchemaMigration.create(name=name)
+
+        logger.info("Applied %d migration(s).", len(pending))
+    finally:
+        db.close()
 
 
-def run_migrations():
-    _ensure_tracking_table()
-    applied = _applied_migrations()
+def show_status() -> None:
+    db = _connect()
+    try:
+        applied = _applied()
+        for name in _discover():
+            logger.info("%-9s %s", "applied" if name in applied else "pending", name)
+    finally:
+        db.close()
 
-    migrations = sorted(f for f in os.listdir(MIGRATIONS_DIR) if f.endswith(".py"))
 
-    for migration in migrations:
-        if migration in applied:
-            print(f"Skipping {migration} (already applied)")
-            continue
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
 
-        migration_path = os.path.join(MIGRATIONS_DIR, migration)
-        print(f"Running migration: {migration}...", end="", flush=True)
-        _run_migration_script(migration_path)
-        SchemaMigration.create(name=migration)
-        print(" Done.")
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--status", action="store_true", help="list migrations without applying them"
+    )
+    args = parser.parse_args()
+
+    if args.status:
+        show_status()
+    else:
+        run_migrations()
 
 
 if __name__ == "__main__":
-    run_migrations()
+    main()

--- a/migrate.py
+++ b/migrate.py
@@ -19,19 +19,25 @@ import os
 import re
 import sys
 
-from peewee import CharField, DateTimeField, Model
+from peewee import CharField, DateTimeField, Model, SqliteDatabase
 
 ROOT = os.path.dirname(os.path.abspath(__file__))
 
 # Migrations import migrations.helpers by name, so the project root has to be
-# importable no matter which directory this was invoked from.
-if ROOT not in sys.path:
-    sys.path.insert(0, ROOT)
+# importable no matter which directory this was invoked from. app/ goes on the
+# path for the same reason app/run.py puts it there: its modules import each
+# other by bare name.
+for _path in (ROOT, os.path.join(ROOT, "app")):
+    if _path not in sys.path:
+        sys.path.insert(0, _path)
+
+from utils.db_backup import prune, snapshot  # noqa: E402
 
 from migrations.helpers import MigrationContext, create_database  # noqa: E402
 
 MIGRATIONS_DIR = os.path.join(ROOT, "migrations")
 MIGRATION_PATTERN = re.compile(r"^\d{3}_\w+\.py$")
+BACKUP_SUBDIR = "pre_migration"
 
 logger = logging.getLogger("migrate")
 
@@ -68,6 +74,37 @@ def _summary(module) -> str:
     return f": {doc[0]}" if doc else ""
 
 
+def _backup(db) -> None:
+    """Snapshot the database before anything is applied.
+
+    Migrations run unattended on every deploy and some of them delete rows, so
+    a run that is about to change something takes a restore point first. A
+    failure here aborts the run: the whole point is not to migrate without one.
+    Set DATABASE_BACKUP_DIRECTORY empty to opt out, as DatabaseBackup does.
+    """
+    if not isinstance(db, SqliteDatabase):
+        logger.info("Skipping pre-migration backup: only supported for SQLite.")
+        return
+
+    backup_dir = os.getenv("DATABASE_BACKUP_DIRECTORY", "db_backups")
+    if not backup_dir:
+        logger.info("Skipping pre-migration backup: backups are disabled.")
+        return
+
+    source = db.database
+    if not os.path.exists(source):
+        return  # a database created by this run has nothing worth keeping
+
+    directory = os.path.join(backup_dir, BACKUP_SUBDIR)
+    os.makedirs(directory, exist_ok=True)
+    timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+    dest = os.path.join(directory, f"pre_migration_{timestamp}.db")
+
+    snapshot(source, dest)
+    logger.info("Backed up to %s (%d bytes)", dest, os.path.getsize(dest))
+    prune(directory, int(os.getenv("DATABASE_BACKUP_RETENTION", 7)))
+
+
 def _connect():
     db = create_database()
     db.connect(reuse_if_open=True)
@@ -89,6 +126,8 @@ def run_migrations() -> None:
         if not pending:
             logger.info("No pending migrations.")
             return
+
+        _backup(db)
 
         ctx = MigrationContext(db)
         for name in pending:

--- a/migrations/001_change_instafix_table_name.py
+++ b/migrations/001_change_instafix_table_name.py
@@ -1,25 +1,7 @@
-# 001_change_insta_table_name.py
+"""Rename instafix_config to instaembed_config."""
 
-import os
-
-from dotenv import load_dotenv
-from playhouse.migrate import *
-
-load_dotenv()
-
-old_table_name = "instafix_config"
-new_table_name = "instaembed_config"
-
-db = SqliteDatabase(os.getenv("SQLITE_DB"))
-
-migrator = SqliteMigrator(db)
+from migrations.helpers import MigrationContext
 
 
-def run():
-    # check if the old and new tables exists
-    if old_table_name in db.get_tables() and new_table_name not in db.get_tables():
-        migrate(
-            migrator.rename_table(old_table_name, new_table_name),
-        )
-    else:
-        print(f"Table '{old_table_name}' does not exist. No changes made.")
+def upgrade(ctx: MigrationContext) -> None:
+    ctx.rename_table("instafix_config", "instaembed_config")

--- a/migrations/002_change_twitterfix_table_name.py
+++ b/migrations/002_change_twitterfix_table_name.py
@@ -1,25 +1,7 @@
-# 002_change_twitterfix_table_name.py
+"""Rename twitterfix_config to twitterembed_config."""
 
-import os
-
-from dotenv import load_dotenv
-from playhouse.migrate import *
-
-load_dotenv()
-
-old_table_name = "twitterfix_config"
-new_table_name = "twitterembed_config"
-
-db = SqliteDatabase(os.getenv("SQLITE_DB"))
-
-migrator = SqliteMigrator(db)
+from migrations.helpers import MigrationContext
 
 
-def run():
-    # check if the old and new tables exists
-    if old_table_name in db.get_tables() and new_table_name not in db.get_tables():
-        migrate(
-            migrator.rename_table(old_table_name, new_table_name),
-        )
-    else:
-        print(f"Table '{old_table_name}' does not exist. No changes made.")
+def upgrade(ctx: MigrationContext) -> None:
+    ctx.rename_table("twitterfix_config", "twitterembed_config")

--- a/migrations/003_change_tiktokfix_table_name.py
+++ b/migrations/003_change_tiktokfix_table_name.py
@@ -1,25 +1,7 @@
-# 003_change_tiktokfix_table_name.py
+"""Rename tiktokfix_config to tiktokembed_config."""
 
-import os
-
-from dotenv import load_dotenv
-from playhouse.migrate import *
-
-load_dotenv()
-
-old_table_name = "tiktokfix_config"
-new_table_name = "tiktokembed_config"
-
-db = SqliteDatabase(os.getenv("SQLITE_DB"))
-
-migrator = SqliteMigrator(db)
+from migrations.helpers import MigrationContext
 
 
-def run():
-    # check if the old and new tables exists
-    if old_table_name in db.get_tables() and new_table_name not in db.get_tables():
-        migrate(
-            migrator.rename_table(old_table_name, new_table_name),
-        )
-    else:
-        print(f"Table '{old_table_name}' does not exist. No changes made.")
+def upgrade(ctx: MigrationContext) -> None:
+    ctx.rename_table("tiktokfix_config", "tiktokembed_config")

--- a/migrations/004_add_incidents_client_options.py
+++ b/migrations/004_add_incidents_client_options.py
@@ -1,27 +1,12 @@
-# 004_add_incidents_client_options.py
+"""Track the latest incident timestamp per guild."""
 
-import os
+from peewee import IntegerField
 
-from dotenv import load_dotenv
-from playhouse.migrate import *
-
-load_dotenv()
-
-table_name = "incidents_config"
-
-db = SqliteDatabase(os.getenv("SQLITE_DB"))
-
-migrator = SqliteMigrator(db)
-
-new_columns = {
-    "latest_incident_timestamp": IntegerField(null=True),
-}
+from migrations.helpers import MigrationContext
 
 
-def run():
-    existing_columns = db.get_columns(table_name)
-    for column_name, field in new_columns.items():
-        if column_name not in [col.name for col in existing_columns]:
-            migrate(migrator.add_column(table_name, column_name, field))
-        else:
-            print(f"Column '{column_name}' already exists. No changes made.")
+def upgrade(ctx: MigrationContext) -> None:
+    ctx.add_columns(
+        "incidents_config",
+        latest_incident_timestamp=IntegerField(null=True),
+    )

--- a/migrations/005_custom_commands_channel_id.py
+++ b/migrations/005_custom_commands_channel_id.py
@@ -1,27 +1,9 @@
-# 005_custom_commands_channel_id.py
+"""Scope custom commands to a channel."""
 
-import os
+from peewee import IntegerField
 
-from dotenv import load_dotenv
-from playhouse.migrate import *
-
-load_dotenv()
-
-table_name = "custom_commands"
-
-db = SqliteDatabase(os.getenv("SQLITE_DB"))
-
-migrator = SqliteMigrator(db)
-
-new_columns = {
-    "channel_id": IntegerField(null=True),
-}
+from migrations.helpers import MigrationContext
 
 
-def run():
-    existing_columns = db.get_columns(table_name)
-    for column_name, field in new_columns.items():
-        if column_name not in [col.name for col in existing_columns]:
-            migrate(migrator.add_column(table_name, column_name, field))
-        else:
-            print(f"Column '{column_name}' already exists. No changes made.")
+def upgrade(ctx: MigrationContext) -> None:
+    ctx.add_columns("custom_commands", channel_id=IntegerField(null=True))

--- a/migrations/006_pdf_preview_guild_config.py
+++ b/migrations/006_pdf_preview_guild_config.py
@@ -1,28 +1,13 @@
-# 006_pdf_preview_guild_config.py
+"""Add page count and virus check options to the PDF preview config."""
 
-import os
+from peewee import BooleanField, IntegerField
 
-from dotenv import load_dotenv
-from playhouse.migrate import *
-
-load_dotenv()
-
-table_name = "pdf_preview_config"
-
-db = SqliteDatabase(os.getenv("SQLITE_DB"))
-
-migrator = SqliteMigrator(db)
-
-new_columns = {
-    "preview_pages": IntegerField(default=1),
-    "virus_check": BooleanField(default=True),
-}
+from migrations.helpers import MigrationContext
 
 
-def run():
-    existing_columns = db.get_columns(table_name)
-    for column_name, field in new_columns.items():
-        if column_name not in [col.name for col in existing_columns]:
-            migrate(migrator.add_column(table_name, column_name, field))
-        else:
-            print(f"Column '{column_name}' already exists. No changes made.")
+def upgrade(ctx: MigrationContext) -> None:
+    ctx.add_columns(
+        "pdf_preview_config",
+        preview_pages=IntegerField(default=1),
+        virus_check=BooleanField(default=True),
+    )

--- a/migrations/007_fix_autoresponse_table.py
+++ b/migrations/007_fix_autoresponse_table.py
@@ -1,25 +1,7 @@
-# 007_fix_autoresponse_table.py
+"""Rename the hyphenated auto-response table to auto_response."""
 
-import os
-
-from dotenv import load_dotenv
-from playhouse.migrate import *
-
-load_dotenv()
-
-old_table_name = "auto-response"
-new_table_name = "auto_response"
-
-db = SqliteDatabase(os.getenv("SQLITE_DB"))
-
-migrator = SqliteMigrator(db)
+from migrations.helpers import MigrationContext
 
 
-def run():
-    # check if the old and new tables exists
-    if old_table_name in db.get_tables() and new_table_name not in db.get_tables():
-        migrate(
-            migrator.rename_table(old_table_name, new_table_name),
-        )
-    else:
-        print(f"Table '{old_table_name}' does not exist. No changes made.")
+def upgrade(ctx: MigrationContext) -> None:
+    ctx.rename_table("auto-response", "auto_response")

--- a/migrations/008_custom_commands_ai_meta.py
+++ b/migrations/008_custom_commands_ai_meta.py
@@ -1,48 +1,20 @@
-# 008_custom_commands_ai_meta.py
+"""Add authorship, cooldown and AI metadata to custom commands."""
 
-import os
+from peewee import BigIntegerField, CharField, DateTimeField, IntegerField
 
-from dotenv import load_dotenv
-from playhouse.migrate import *
-
-load_dotenv()
-
-table_name = "custom_commands"
-
-db = SqliteDatabase(os.getenv("SQLITE_DB"))
-
-migrator = SqliteMigrator(db)
+from migrations.helpers import MigrationContext
 
 
-def run():
-    new_columns = {
-        "command_type": CharField(default="basic", null=False),
-        "last_updated": DateTimeField(null=True),
-        "author": BigIntegerField(null=True),
-        "cooldown": IntegerField(default=0),
-        "last_used": DateTimeField(null=True),
-        "owner": BigIntegerField(null=True),
-    }
+def upgrade(ctx: MigrationContext) -> None:
+    ctx.add_columns(
+        "custom_commands",
+        command_type=CharField(default="basic", null=False),
+        last_updated=DateTimeField(null=True),
+        author=BigIntegerField(null=True),
+        cooldown=IntegerField(default=0),
+        last_used=DateTimeField(null=True),
+        owner=BigIntegerField(null=True),
+    )
 
-    updated_columns = {
-        "command_response": CharField(null=True),
-    }
-
-    existing_columns = db.get_columns(table_name)
-    for column_name, field in new_columns.items():
-        if column_name not in [col.name for col in existing_columns]:
-            migrate(migrator.add_column(table_name, column_name, field))
-        else:
-            print(f"Column '{column_name}' already exists. No changes made.")
-
-    for column_name, field in updated_columns.items():
-        for col in existing_columns:
-            if col.name == column_name:
-                if not col.null and isinstance(field, CharField) and field.null:
-                    migrate(migrator.drop_not_null(table_name, column_name))
-                    print(f"Column '{column_name}' altered to allow NULL values.")
-                else:
-                    print(
-                        f"Column '{column_name}' already has the desired properties. No changes made."
-                    )
-                break
+    # AI commands have no static response text
+    ctx.drop_not_null("custom_commands", "command_response")

--- a/migrations/009_custom_commands_cooldown_fix.py
+++ b/migrations/009_custom_commands_cooldown_fix.py
@@ -1,33 +1,14 @@
-# 009_custom_commands_cooldown_fix.py
-# cooldown was added as NOT NULL in 008 without a proper DB-level default,
-# which causes SQLite to reject INSERTs that don't explicitly set the column.
-# This migration ensures the column exists and is nullable.
+"""Make custom command cooldowns nullable.
 
-import os
+008 added cooldown as NOT NULL without a DB level default, which makes SQLite
+reject INSERTs that do not set the column explicitly.
+"""
 
-from dotenv import load_dotenv
-from playhouse.migrate import *
+from peewee import IntegerField
 
-load_dotenv()
-
-table_name = "custom_commands"
-
-db = SqliteDatabase(os.getenv("SQLITE_DB"))
-
-migrator = SqliteMigrator(db)
+from migrations.helpers import MigrationContext
 
 
-def run():
-    existing_columns = db.get_columns(table_name)
-    col_names = [col.name for col in existing_columns]
-
-    if "cooldown" not in col_names:
-        migrate(
-            migrator.add_column(
-                table_name, "cooldown", IntegerField(default=0, null=True)
-            )
-        )
-    else:
-        col = next(c for c in existing_columns if c.name == "cooldown")
-        if not col.null:
-            migrate(migrator.drop_not_null(table_name, "cooldown"))
+def upgrade(ctx: MigrationContext) -> None:
+    ctx.add_columns("custom_commands", cooldown=IntegerField(default=0, null=True))
+    ctx.drop_not_null("custom_commands", "cooldown")

--- a/migrations/010_reddit_feed_post_tracking.py
+++ b/migrations/010_reddit_feed_post_tracking.py
@@ -1,33 +1,18 @@
-# 007_reddit_feed_post_tracking.py
+"""Track score, comment count and edit state on synced reddit posts."""
 
-import os
+from peewee import BooleanField, DateTimeField, IntegerField
 
-from dotenv import load_dotenv
-from playhouse.migrate import *
-
-load_dotenv()
-
-table_name = "reddit_post"
-
-db = SqliteDatabase(os.getenv("SQLITE_DB"))
-
-migrator = SqliteMigrator(db)
-
-new_columns = {
-    "comment_count": IntegerField(null=True),
-    "score": IntegerField(null=True),
-    "deleted": BooleanField(default=False),
-    "edited": BooleanField(default=False),
-    "removed": BooleanField(default=False),
-    "last_updated": DateTimeField(null=True),
-    "channel_id": IntegerField(null=True),
-}
+from migrations.helpers import MigrationContext
 
 
-def run():
-    existing_columns = db.get_columns(table_name)
-    for column_name, field in new_columns.items():
-        if column_name not in [col.name for col in existing_columns]:
-            migrate(migrator.add_column(table_name, column_name, field))
-        else:
-            print(f"Column '{column_name}' already exists. No changes made.")
+def upgrade(ctx: MigrationContext) -> None:
+    ctx.add_columns(
+        "reddit_post",
+        comment_count=IntegerField(null=True),
+        score=IntegerField(null=True),
+        deleted=BooleanField(default=False),
+        edited=BooleanField(default=False),
+        removed=BooleanField(default=False),
+        last_updated=DateTimeField(null=True),
+        channel_id=IntegerField(null=True),
+    )

--- a/migrations/011_guild_config_prefix.py
+++ b/migrations/011_guild_config_prefix.py
@@ -1,25 +1,9 @@
-import os
+"""Add a per-guild command prefix."""
 
-from dotenv import load_dotenv
-from playhouse.migrate import *
+from peewee import CharField
 
-load_dotenv()
-
-db = SqliteDatabase(os.getenv("SQLITE_DB"))
-
-migrator = SqliteMigrator(db)
-
-table_name = "guild_configs"
-
-new_columns = {
-    "prefix": CharField(default="."),
-}
+from migrations.helpers import MigrationContext
 
 
-def run():
-    existing_columns = db.get_columns(table_name)
-    for column_name, field in new_columns.items():
-        if column_name not in [col.name for col in existing_columns]:
-            migrate(migrator.add_column(table_name, column_name, field))
-        else:
-            print(f"Column '{column_name}' already exists. No changes made.")
+def upgrade(ctx: MigrationContext) -> None:
+    ctx.add_columns("guild_configs", prefix=CharField(default="."))

--- a/migrations/012_tech_lanc_config_schedule.py
+++ b/migrations/012_tech_lanc_config_schedule.py
@@ -1,30 +1,14 @@
-import os
+"""Make the tech lanc post schedule configurable."""
 
-from dotenv import load_dotenv
-from playhouse.migrate import *
+from peewee import IntegerField
 
-load_dotenv()
-
-db = SqliteDatabase(os.getenv("SQLITE_DB"))
-
-migrator = SqliteMigrator(db)
-
-table_name = "tech_lanc_config"
-
-new_columns = {
-    "day_of_week": IntegerField(default=0),
-    "post_hour": IntegerField(default=8),
-    "post_minute": IntegerField(default=0),
-}
+from migrations.helpers import MigrationContext
 
 
-def run():
-    if table_name not in db.get_tables():
-        print(f"Table '{table_name}' does not exist. No changes made.")
-        return
-    existing_columns = db.get_columns(table_name)
-    for column_name, field in new_columns.items():
-        if column_name not in [col.name for col in existing_columns]:
-            migrate(migrator.add_column(table_name, column_name, field))
-        else:
-            print(f"Column '{column_name}' already exists. No changes made.")
+def upgrade(ctx: MigrationContext) -> None:
+    ctx.add_columns(
+        "tech_lanc_config",
+        day_of_week=IntegerField(default=0),
+        post_hour=IntegerField(default=8),
+        post_minute=IntegerField(default=0),
+    )

--- a/migrations/013_geoguesser_updates.py
+++ b/migrations/013_geoguesser_updates.py
@@ -1,71 +1,39 @@
-import os
+"""Label geoguesser locations and record per-game results."""
 
-from dotenv import load_dotenv
-from playhouse.migrate import *
+from peewee import (
+    AutoField,
+    BigIntegerField,
+    CharField,
+    DateTimeField,
+    FloatField,
+    IntegerField,
+    Model,
+    UUIDField,
+)
 
-load_dotenv()
-
-db = SqliteDatabase(os.getenv("SQLITE_DB"))
-
-migrator = SqliteMigrator(db)
+from migrations.helpers import MigrationContext
 
 
-def run():
-    # add label column to geoguesser_locations
-    if "geoguesser_locations" in db.get_tables():
-        existing_columns = [col.name for col in db.get_columns("geoguesser_locations")]
-        if "label" not in existing_columns:
-            migrate(
-                migrator.add_column(
-                    "geoguesser_locations", "label", CharField(null=True)
-                )
-            )
-            print("Added 'label' column to geoguesser_locations.")
-        else:
-            print("Column 'label' already exists. No changes made.")
-    else:
-        print("Table 'geoguesser_locations' does not exist. No changes made.")
+class GeoguesserGameResult(Model):
+    id = AutoField()
+    game_id = UUIDField()
+    guild_id = BigIntegerField()
+    user_id = BigIntegerField()
+    mode = CharField()
+    score = FloatField()
+    rounds_played = IntegerField()
+    played_at = DateTimeField()
 
-    # create geoguesser_game_results table
-    if "geoguesser_game_results" not in db.get_tables():
-        db.execute_sql("""
-            CREATE TABLE geoguesser_game_results (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                game_id TEXT NOT NULL,
-                guild_id INTEGER NOT NULL,
-                user_id INTEGER NOT NULL,
-                mode TEXT NOT NULL,
-                score REAL NOT NULL,
-                rounds_played INTEGER NOT NULL,
-                played_at DATETIME NOT NULL
-            )
-        """)
-        db.execute_sql(
-            "CREATE INDEX idx_ggr_guild ON geoguesser_game_results (guild_id)"
-        )
-        db.execute_sql(
-            "CREATE INDEX idx_ggr_user ON geoguesser_game_results (guild_id, user_id)"
-        )
-        db.execute_sql(
-            "CREATE INDEX idx_ggr_played_at ON geoguesser_game_results (played_at)"
-        )
-        print("Created table 'geoguesser_game_results' with indexes.")
-    else:
-        print("Table 'geoguesser_game_results' already exists. No changes made.")
+    class Meta:
+        table_name = "geoguesser_game_results"
 
-    # add scoring_version column if missing
-    if "geoguesser_game_results" in db.get_tables():
-        existing_columns = [
-            col.name for col in db.get_columns("geoguesser_game_results")
-        ]
-        if "scoring_version" not in existing_columns:
-            migrate(
-                migrator.add_column(
-                    "geoguesser_game_results",
-                    "scoring_version",
-                    IntegerField(default=1),
-                )
-            )
-            print("Added 'scoring_version' column to geoguesser_game_results.")
-        else:
-            print("Column 'scoring_version' already exists. No changes made.")
+
+def upgrade(ctx: MigrationContext) -> None:
+    ctx.add_columns("geoguesser_locations", label=CharField(null=True))
+
+    ctx.create_table(GeoguesserGameResult)
+    ctx.create_index("geoguesser_game_results", "idx_ggr_guild", ["guild_id"])
+    ctx.create_index("geoguesser_game_results", "idx_ggr_user", ["guild_id", "user_id"])
+    ctx.create_index("geoguesser_game_results", "idx_ggr_played_at", ["played_at"])
+
+    ctx.add_columns("geoguesser_game_results", scoring_version=IntegerField(default=1))

--- a/migrations/014_round_game_results.py
+++ b/migrations/014_round_game_results.py
@@ -1,35 +1,40 @@
-import os
+"""Add the shared results table used by all round based games."""
 
-from dotenv import load_dotenv
-from playhouse.migrate import *
+from peewee import (
+    AutoField,
+    BigIntegerField,
+    CharField,
+    DateTimeField,
+    FloatField,
+    IntegerField,
+    Model,
+    UUIDField,
+)
 
-load_dotenv()
-
-db = SqliteDatabase(os.getenv("SQLITE_DB"))
+from migrations.helpers import MigrationContext
 
 
-def run():
-    if "round_game_results" not in db.get_tables():
-        db.execute_sql("""
-            CREATE TABLE round_game_results (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                game_name TEXT NOT NULL,
-                game_id TEXT NOT NULL,
-                guild_id INTEGER NOT NULL,
-                user_id INTEGER NOT NULL,
-                mode TEXT NOT NULL,
-                score REAL NOT NULL,
-                rounds_played INTEGER NOT NULL,
-                scoring_version INTEGER NOT NULL,
-                played_at DATETIME NOT NULL
-            )
-            """)
-        db.execute_sql(
-            "CREATE INDEX idx_rgr_game_guild_user ON round_game_results (game_name, guild_id, user_id)"
-        )
-        db.execute_sql(
-            "CREATE INDEX idx_rgr_game_id ON round_game_results (game_name, game_id)"
-        )
-        print("Created table 'round_game_results' with indexes.")
-    else:
-        print("Table 'round_game_results' already exists. No changes made.")
+class RoundGameResult(Model):
+    id = AutoField()
+    game_name = CharField()
+    game_id = UUIDField()
+    guild_id = BigIntegerField()
+    user_id = BigIntegerField()
+    mode = CharField()
+    score = FloatField()
+    rounds_played = IntegerField()
+    scoring_version = IntegerField()
+    played_at = DateTimeField()
+
+    class Meta:
+        table_name = "round_game_results"
+
+
+def upgrade(ctx: MigrationContext) -> None:
+    ctx.create_table(RoundGameResult)
+    ctx.create_index(
+        "round_game_results",
+        "idx_rgr_game_guild_user",
+        ["game_name", "guild_id", "user_id"],
+    )
+    ctx.create_index("round_game_results", "idx_rgr_game_id", ["game_name", "game_id"])

--- a/migrations/015_guild_config_unique_guild_id.py
+++ b/migrations/015_guild_config_unique_guild_id.py
@@ -1,38 +1,25 @@
-import os
+"""Enforce one config row per guild."""
 
-from dotenv import load_dotenv
-from peewee import *
-
-load_dotenv()
-
-db = SqliteDatabase(os.getenv("SQLITE_DB"))
+from migrations.helpers import MigrationContext
 
 TABLE = "guild_configs"
 
 
-def run():
-    db.connect(reuse_if_open=True)
-
-    if TABLE not in db.get_tables():
-        print(f"Table '{TABLE}' does not exist. No changes made.")
+def upgrade(ctx: MigrationContext) -> None:
+    if not ctx.table_exists(TABLE):
         return
 
-    # Deduplicate: keep the row with the lowest rowid for each guild_id.
-    db.execute_sql(f"""
+    # Keep the oldest row for each guild. rowid is SQLite specific, which is
+    # the only backend this ran against.
+    ctx.execute(
+        f"""
         DELETE FROM {TABLE}
         WHERE rowid NOT IN (
             SELECT MIN(rowid) FROM {TABLE} GROUP BY guild_id
         )
-    """)
+    """
+    )
 
-    # SQLite doesn't support ADD CONSTRAINT on existing tables, so we
-    # recreate the table with a unique index on guild_id instead.
-    indexes = db.get_indexes(TABLE)
-    index_names = [idx.name for idx in indexes]
-    if "guild_configs_guild_id" not in index_names:
-        db.execute_sql(
-            f"CREATE UNIQUE INDEX guild_configs_guild_id ON {TABLE} (guild_id)"
-        )
-        print(f"Added unique index on {TABLE}.guild_id")
-    else:
-        print("Unique index on guild_id already exists. No changes made.")
+    # SQLite cannot ADD CONSTRAINT to an existing table, so uniqueness comes
+    # from an index instead.
+    ctx.create_index(TABLE, "guild_configs_guild_id", ["guild_id"], unique=True)

--- a/migrations/016_embedfix_handler_id.py
+++ b/migrations/016_embedfix_handler_id.py
@@ -1,13 +1,8 @@
-import os
+"""Record which handler each embed fix config uses."""
 
-from dotenv import load_dotenv
-from playhouse.migrate import *
+from peewee import CharField
 
-load_dotenv()
-
-db = SqliteDatabase(os.getenv("SQLITE_DB"))
-
-migrator = SqliteMigrator(db)
+from migrations.helpers import MigrationContext
 
 TABLES = [
     "twitterembed_config",
@@ -18,15 +13,6 @@ TABLES = [
 ]
 
 
-def run():
-    existing_tables = db.get_tables()
+def upgrade(ctx: MigrationContext) -> None:
     for table in TABLES:
-        if table not in existing_tables:
-            print(f"Table '{table}' does not exist, skipping.")
-            continue
-        existing_columns = [col.name for col in db.get_columns(table)]
-        if "handler_id" not in existing_columns:
-            migrate(migrator.add_column(table, "handler_id", CharField(default="")))
-            print(f"Added 'handler_id' column to {table}.")
-        else:
-            print(f"Column 'handler_id' already exists in {table}. No changes made.")
+        ctx.add_columns(table, handler_id=CharField(default=""))

--- a/migrations/017_paywall_bypass_handler_id.py
+++ b/migrations/017_paywall_bypass_handler_id.py
@@ -1,26 +1,9 @@
-import os
+"""Record which handler the paywall bypass config uses."""
 
-from dotenv import load_dotenv
-from playhouse.migrate import *
+from peewee import CharField
 
-load_dotenv()
-
-db = SqliteDatabase(os.getenv("SQLITE_DB"))
-
-migrator = SqliteMigrator(db)
-
-TABLE = "paywall_bypass_config"
+from migrations.helpers import MigrationContext
 
 
-def run():
-    existing_tables = db.get_tables()
-    if TABLE not in existing_tables:
-        print(f"Table '{TABLE}' does not exist, skipping.")
-        return
-
-    existing_columns = [col.name for col in db.get_columns(TABLE)]
-    if "handler_id" not in existing_columns:
-        migrate(migrator.add_column(TABLE, "handler_id", CharField(default="")))
-        print(f"Added 'handler_id' column to {TABLE}.")
-    else:
-        print(f"Column 'handler_id' already exists in {TABLE}. No changes made.")
+def upgrade(ctx: MigrationContext) -> None:
+    ctx.add_columns("paywall_bypass_config", handler_id=CharField(default=""))

--- a/migrations/018_paywall_pattern.py
+++ b/migrations/018_paywall_pattern.py
@@ -1,26 +1,19 @@
-import os
+"""Add per-guild paywall URL patterns."""
 
-from dotenv import load_dotenv
-from playhouse.migrate import *
+from peewee import AutoField, BigIntegerField, CharField, Model
 
-load_dotenv()
-
-db = SqliteDatabase(os.getenv("SQLITE_DB"))
-
-TABLE = "paywall_pattern"
+from migrations.helpers import MigrationContext
 
 
-def run():
-    existing_tables = db.get_tables()
-    if TABLE not in existing_tables:
-        db.execute_sql(f"""
-            CREATE TABLE {TABLE} (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                guild_id BIGINT NOT NULL,
-                pattern VARCHAR(255) NOT NULL
-            )
-            """)
-        db.execute_sql(f"CREATE INDEX idx_{TABLE}_guild_id ON {TABLE} (guild_id)")
-        print(f"Created table '{TABLE}'.")
-    else:
-        print(f"Table '{TABLE}' already exists. No changes made.")
+class PaywallPattern(Model):
+    id = AutoField()
+    guild_id = BigIntegerField()
+    pattern = CharField()
+
+    class Meta:
+        table_name = "paywall_pattern"
+
+
+def upgrade(ctx: MigrationContext) -> None:
+    ctx.create_table(PaywallPattern)
+    ctx.create_index("paywall_pattern", "idx_paywall_pattern_guild_id", ["guild_id"])

--- a/migrations/019_reddit_feed_removed_by_reddit.py
+++ b/migrations/019_reddit_feed_removed_by_reddit.py
@@ -1,25 +1,9 @@
-import os
+"""Distinguish posts removed by reddit from posts removed by their author."""
 
-from dotenv import load_dotenv
-from playhouse.migrate import *
+from peewee import BooleanField
 
-load_dotenv()
-
-table_name = "reddit_post"
-
-db = SqliteDatabase(os.getenv("SQLITE_DB"))
-
-migrator = SqliteMigrator(db)
-
-new_columns = {
-    "removed_by_reddit": BooleanField(default=False),
-}
+from migrations.helpers import MigrationContext
 
 
-def run():
-    existing_columns = db.get_columns(table_name)
-    for column_name, field in new_columns.items():
-        if column_name not in [col.name for col in existing_columns]:
-            migrate(migrator.add_column(table_name, column_name, field))
-        else:
-            print(f"Column '{column_name}' already exists. No changes made.")
+def upgrade(ctx: MigrationContext) -> None:
+    ctx.add_columns("reddit_post", removed_by_reddit=BooleanField(default=False))

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -1,0 +1,68 @@
+# Migrations
+
+Sequential schema changes applied by `migrate.py`.
+
+```bash
+poetry run migrate            # apply pending migrations
+poetry run migrate --status   # list applied and pending migrations
+```
+
+The runner records each applied filename in the `schema_migrations` table, so a
+migration runs once. The schema change and that bookkeeping row share a
+transaction: if a migration raises, nothing is committed and it is retried on
+the next run. (SQLite makes DDL transactional. MySQL commits implicitly on DDL,
+so there the guarantee is best effort.)
+
+Migrations run before the bot starts, ahead of the cogs that create their own
+tables, so a table a migration targets may not exist yet. Operations against a
+missing table are skipped rather than raising.
+
+## Writing one
+
+Create `NNN_short_description.py` with the next number. Files that do not match
+`NNN_name.py` are ignored by the runner, so `helpers.py` and this README are
+safe to keep here.
+
+```python
+"""One line describing the change, printed when the migration runs."""
+
+from peewee import BooleanField
+
+from migrations.helpers import MigrationContext
+
+
+def upgrade(ctx: MigrationContext) -> None:
+    ctx.add_columns("reddit_post", removed_by_reddit=BooleanField(default=False))
+```
+
+Rules:
+
+- One `upgrade(ctx)` function per file. No work at import time, and never open
+  your own connection: `ctx` owns the connection and the right migrator for the
+  configured `DB_TYPE`.
+- Never rename a migration file after it has shipped. The filename is the key in
+  `schema_migrations`; renaming makes it look unapplied everywhere it already ran.
+- Never edit a migration that has shipped. Add a new one, as 009 does for 008.
+- Never import models from `app`. A migration is a snapshot of the schema at one
+  point in time; a live model would silently change what an old migration does
+  as the model evolves. Declare a local `Model` for new tables instead.
+
+## Context API
+
+Every operation is idempotent: it inspects the current schema first and logs a
+skip when the change is already present. That matters because the tracking table
+was added after several migrations had shipped, so a production database may
+replay the whole history.
+
+| Method | Purpose |
+| --- | --- |
+| `add_columns(table, **fields)` | Add each column that is missing |
+| `drop_not_null(table, *columns)` | Make columns nullable |
+| `rename_table(old, new)` | Rename, if `old` exists and `new` does not |
+| `create_table(model)` | Create the table for a locally declared model |
+| `create_index(table, name, columns, unique=False)` | Create a named index |
+| `table_exists` / `column_exists` / `index_exists` | Introspection |
+| `execute(sql, *params)` | Escape hatch for anything else |
+
+`create_table` creates only the table. Declare indexes explicitly with
+`create_index` so their names are stable rather than derived by Peewee.

--- a/migrations/__init__.py
+++ b/migrations/__init__.py
@@ -1,0 +1,6 @@
+"""Sequential database migrations applied by ``migrate.py``.
+
+Migration modules are named ``NNN_description.py`` and are discovered by that
+pattern, so any other module in this package (``helpers.py``, this file) is
+ignored by the runner.
+"""

--- a/migrations/helpers.py
+++ b/migrations/helpers.py
@@ -1,0 +1,175 @@
+"""Shared plumbing for migration scripts.
+
+Every migration exposes a single ``upgrade(ctx)`` function and does its work
+through the :class:`MigrationContext` it is handed. The context owns the
+connection, the dialect-appropriate migrator, and a set of idempotent
+operations, so no migration opens its own database or hand-rolls a
+"does this column already exist" check.
+
+Operations are idempotent on purpose. The ``schema_migrations`` tracking table
+was introduced after several migrations had already been applied in
+production, so a migration must be a no-op when the database already has the
+change. Operations against a missing table are skipped rather than raising:
+cogs create their own tables at load time, so a table may legitimately not
+exist yet on a fresh database or when a cog is blacklisted.
+
+Migrations never import models from ``app``. A migration is a snapshot of the
+schema at one point in time; importing a live model would silently change what
+an old migration does every time that model evolves.
+"""
+
+import logging
+import os
+
+from dotenv import load_dotenv
+from peewee import Database, Entity, Index, Model, MySQLDatabase, SqliteDatabase
+from playhouse.migrate import MySQLMigrator, SchemaMigrator, SqliteMigrator, migrate
+
+logger = logging.getLogger("migrate")
+
+
+def create_database() -> Database:
+    """Build the database described by the environment.
+
+    Mirrors ``init_db()`` in ``app/main.py`` but without importing the bot, so
+    migrations can run in a container step of their own. SQLite pragmas are
+    left at their defaults here: the migrator rebuilds tables to alter columns,
+    which does not mix well with foreign key enforcement.
+    """
+    load_dotenv()
+    db_type = os.getenv("DB_TYPE", "sqlite").lower()
+
+    if db_type == "sqlite":
+        path = os.getenv("SQLITE_DB", "data/lancobot.db")
+        directory = os.path.dirname(path)
+        if directory:
+            os.makedirs(directory, exist_ok=True)
+        return SqliteDatabase(path)
+
+    if db_type == "mysql":
+        return MySQLDatabase(
+            os.getenv("MYSQL_DB"),
+            user=os.getenv("MYSQL_USER"),
+            password=os.getenv("MYSQL_PASSWORD"),
+            host=os.getenv("MYSQL_HOST"),
+            port=int(os.getenv("MYSQL_PORT", 3306)),
+        )
+
+    raise ValueError(f"Unsupported database type: {db_type}")
+
+
+def create_migrator(db: Database) -> SchemaMigrator:
+    return MySQLMigrator(db) if isinstance(db, MySQLDatabase) else SqliteMigrator(db)
+
+
+class MigrationContext:
+    """Idempotent schema operations bound to a single connection."""
+
+    def __init__(self, db: Database):
+        self.db = db
+        self.migrator = create_migrator(db)
+
+    # introspection
+
+    def table_exists(self, table: str) -> bool:
+        return table in self.db.get_tables()
+
+    def column_exists(self, table: str, column: str) -> bool:
+        return column in self._column_names(table)
+
+    def index_exists(self, table: str, index: str) -> bool:
+        return index in {idx.name for idx in self.db.get_indexes(table)}
+
+    # operations
+
+    def add_columns(self, table: str, **columns) -> None:
+        """Add each ``name=Field(...)`` column that is not already present."""
+        if not self._require_table(table):
+            return
+
+        existing = self._column_names(table)
+        for name, field in columns.items():
+            if name in existing:
+                logger.info("  %s.%s already exists, skipping", table, name)
+                continue
+            migrate(self.migrator.add_column(table, name, field))
+            logger.info("  added %s.%s", table, name)
+
+    def drop_not_null(self, table: str, *columns: str) -> None:
+        """Make each column nullable if it is currently NOT NULL."""
+        if not self._require_table(table):
+            return
+
+        by_name = {col.name: col for col in self.db.get_columns(table)}
+        for name in columns:
+            column = by_name.get(name)
+            if column is None:
+                logger.info("  %s.%s does not exist, skipping", table, name)
+            elif column.null:
+                logger.info("  %s.%s is already nullable, skipping", table, name)
+            else:
+                migrate(self.migrator.drop_not_null(table, name))
+                logger.info("  dropped NOT NULL from %s.%s", table, name)
+
+    def rename_table(self, old: str, new: str) -> None:
+        tables = set(self.db.get_tables())
+        if old not in tables:
+            logger.info("  table %s does not exist, skipping", old)
+            return
+        if new in tables:
+            logger.info("  table %s already exists, skipping", new)
+            return
+
+        migrate(self.migrator.rename_table(old, new))
+        logger.info("  renamed %s to %s", old, new)
+
+    def create_table(self, model: type[Model]) -> None:
+        """Create the table for a model declared inside a migration.
+
+        Only the table is created; declare indexes explicitly with
+        :meth:`create_index` so their names stay stable across databases.
+        """
+        table = model._meta.table_name
+        if self.table_exists(table):
+            logger.info("  table %s already exists, skipping", table)
+            return
+
+        model.bind(self.db)
+        self.db.create_tables([model])
+        logger.info("  created table %s", table)
+
+    def create_index(
+        self, table: str, name: str, columns: list[str], unique: bool = False
+    ) -> None:
+        if not self._require_table(table):
+            return
+        if self.index_exists(table, name):
+            logger.info("  index %s already exists, skipping", name)
+            return
+
+        # safe=False: IF NOT EXISTS is not valid index syntax on MySQL, and the
+        # check above already makes this a no-op when the index is present.
+        index = Index(
+            name,
+            table,
+            [Entity(column) for column in columns],
+            unique=unique,
+            safe=False,
+        )
+        self.db.execute(index)
+        logger.info("  created index %s on %s", name, table)
+
+    def execute(self, sql: str, *params) -> None:
+        """Escape hatch for changes the helpers above do not cover."""
+        self.db.execute_sql(sql, params)
+
+    # internals
+
+    def _column_names(self, table: str) -> set:
+        return {col.name for col in self.db.get_columns(table)}
+
+    def _require_table(self, table: str) -> bool:
+        if self.table_exists(table):
+            return True
+        logger.info("  table %s does not exist, skipping", table)
+        return False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.scripts]
-migrate = "migrate:run_migrations"
+migrate = "migrate:main"
 bot = "app.run:prod"
 dev = "app.run:dev"
 prod = "app.run:prod"

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,0 +1,152 @@
+"""Migration runner tests.
+
+Migrations must be safe to run against a database at any point in its history:
+a brand new file, a database that predates the tracking table, and one that is
+already fully migrated.
+"""
+
+import sqlite3
+
+import pytest
+from peewee import CharField
+
+import migrate
+
+# Roughly the schema as it stood before 001, enough to exercise the renames,
+# the added columns and the guild_configs dedupe.
+LEGACY_SCHEMA = """
+CREATE TABLE instafix_config (id INTEGER PRIMARY KEY, guild_id INTEGER NOT NULL);
+CREATE TABLE twitterfix_config (id INTEGER PRIMARY KEY, guild_id INTEGER NOT NULL);
+CREATE TABLE tiktokfix_config (id INTEGER PRIMARY KEY, guild_id INTEGER NOT NULL);
+CREATE TABLE "auto-response" (id INTEGER PRIMARY KEY, guild_id INTEGER NOT NULL);
+CREATE TABLE incidents_config (id INTEGER PRIMARY KEY, guild_id INTEGER NOT NULL);
+CREATE TABLE custom_commands (
+    id INTEGER PRIMARY KEY,
+    guild_id INTEGER NOT NULL,
+    command_name VARCHAR(255) NOT NULL,
+    command_response VARCHAR(255) NOT NULL
+);
+CREATE TABLE guild_configs (id INTEGER PRIMARY KEY, guild_id INTEGER NOT NULL);
+
+INSERT INTO custom_commands (guild_id, command_name, command_response)
+    VALUES (1, 'foo', 'bar');
+INSERT INTO guild_configs (guild_id) VALUES (1), (1), (2);
+"""
+
+
+def schema_of(path) -> list:
+    conn = sqlite3.connect(path)
+    try:
+        return conn.execute(
+            "SELECT type, name, sql FROM sqlite_master "
+            "WHERE name NOT LIKE 'sqlite_%' ORDER BY type, name"
+        ).fetchall()
+    finally:
+        conn.close()
+
+
+def columns(path, table) -> dict:
+    conn = sqlite3.connect(path)
+    try:
+        return {row[1]: row for row in conn.execute(f'PRAGMA table_info("{table}")')}
+    finally:
+        conn.close()
+
+
+@pytest.fixture
+def legacy_db(tmp_path, monkeypatch):
+    path = tmp_path / "legacy.db"
+    conn = sqlite3.connect(path)
+    conn.executescript(LEGACY_SCHEMA)
+    conn.commit()
+    conn.close()
+
+    monkeypatch.setenv("DB_TYPE", "sqlite")
+    monkeypatch.setenv("SQLITE_DB", str(path))
+    return path
+
+
+def test_runs_against_an_empty_database(tmp_path, monkeypatch):
+    path = tmp_path / "fresh.db"
+    monkeypatch.setenv("DB_TYPE", "sqlite")
+    monkeypatch.setenv("SQLITE_DB", str(path))
+
+    migrate.run_migrations()
+
+    applied = {row[0] for row in schema_of(path) if row[0] == "table"}
+    assert applied  # tracking table exists, nothing raised
+
+
+def test_applies_legacy_schema_changes(legacy_db):
+    migrate.run_migrations()
+
+    tables = {row[1] for row in schema_of(legacy_db) if row[0] == "table"}
+    assert "instaembed_config" in tables
+    assert "instafix_config" not in tables
+    assert "auto_response" in tables
+
+    custom_commands = columns(legacy_db, "custom_commands")
+    assert "cooldown" in custom_commands
+    assert custom_commands["cooldown"][3] == 0  # nullable, see 009
+    assert custom_commands["command_response"][3] == 0  # nullable, see 008
+
+
+def test_dedupes_guild_configs(legacy_db):
+    migrate.run_migrations()
+
+    conn = sqlite3.connect(legacy_db)
+    try:
+        guild_ids = [
+            row[0] for row in conn.execute("SELECT guild_id FROM guild_configs")
+        ]
+    finally:
+        conn.close()
+
+    assert sorted(guild_ids) == [1, 2]
+
+
+def test_every_migration_is_recorded(legacy_db):
+    migrate.run_migrations()
+
+    conn = sqlite3.connect(legacy_db)
+    try:
+        recorded = {
+            row[0] for row in conn.execute("SELECT name FROM schema_migrations")
+        }
+    finally:
+        conn.close()
+
+    assert recorded == set(migrate._discover())
+
+
+def test_rerunning_from_scratch_is_a_no_op(legacy_db):
+    """A database migrated before the tracking table existed must survive a
+    full replay, which is why every operation checks the current schema."""
+    migrate.run_migrations()
+    before = schema_of(legacy_db)
+
+    conn = sqlite3.connect(legacy_db)
+    conn.execute("DELETE FROM schema_migrations")
+    conn.commit()
+    conn.close()
+
+    migrate.run_migrations()
+    assert schema_of(legacy_db) == before
+
+
+def test_failed_migration_leaves_no_trace(legacy_db, monkeypatch):
+    migrate.run_migrations()
+    before = schema_of(legacy_db)
+
+    def explode(ctx):
+        ctx.add_columns("guild_configs", probe=CharField(null=True))
+        raise RuntimeError("boom")
+
+    module = type("module", (), {"upgrade": staticmethod(explode), "__doc__": None})
+    monkeypatch.setattr(migrate, "_discover", lambda: ["999_probe.py"])
+    monkeypatch.setattr(migrate, "_load", lambda name: module)
+
+    with pytest.raises(RuntimeError):
+        migrate.run_migrations()
+
+    assert schema_of(legacy_db) == before

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -134,6 +134,54 @@ def test_rerunning_from_scratch_is_a_no_op(legacy_db):
     assert schema_of(legacy_db) == before
 
 
+def test_backs_up_before_applying(legacy_db, tmp_path, monkeypatch):
+    monkeypatch.setenv("DATABASE_BACKUP_DIRECTORY", str(tmp_path / "backups"))
+
+    migrate.run_migrations()
+
+    backups = list((tmp_path / "backups" / migrate.BACKUP_SUBDIR).glob("*.db"))
+    assert len(backups) == 1
+
+    # the snapshot predates the migrations, so it still has the old table names
+    restored = {row[1] for row in schema_of(backups[0]) if row[0] == "table"}
+    assert "instafix_config" in restored
+    assert "instaembed_config" not in restored
+
+
+def test_backup_is_skipped_when_nothing_is_pending(legacy_db, tmp_path, monkeypatch):
+    """Every container start runs the migrator; only real work earns a backup."""
+    monkeypatch.setenv("DATABASE_BACKUP_DIRECTORY", str(tmp_path / "backups"))
+    migrate.run_migrations()
+
+    migrate.run_migrations()
+
+    backups = list((tmp_path / "backups" / migrate.BACKUP_SUBDIR).glob("*.db"))
+    assert len(backups) == 1
+
+
+def test_backup_failure_aborts_the_run(legacy_db, tmp_path, monkeypatch):
+    """No restore point means no migration."""
+    monkeypatch.setenv("DATABASE_BACKUP_DIRECTORY", str(tmp_path / "backups"))
+
+    def explode(source, dest):
+        raise OSError("no space left on device")
+
+    monkeypatch.setattr(migrate, "snapshot", explode)
+
+    with pytest.raises(OSError):
+        migrate.run_migrations()
+
+    tables = {row[1] for row in schema_of(legacy_db) if row[0] == "table"}
+    assert "instafix_config" in tables  # 001 never ran
+    assert "instaembed_config" not in tables
+
+    conn = sqlite3.connect(legacy_db)
+    try:
+        assert conn.execute("SELECT COUNT(*) FROM schema_migrations").fetchone()[0] == 0
+    finally:
+        conn.close()
+
+
 def test_failed_migration_leaves_no_trace(legacy_db, monkeypatch):
     migrate.run_migrations()
     before = schema_of(legacy_db)


### PR DESCRIPTION
## Problem

Each of the 19 migrations repeats the same import-time setup and hand-rolls its own "does this column exist" guard, so the real change is two lines buried in twenty. That copy-paste hid three defects: `poetry run migrate` crashes on a new database (004 touches a table the cogs have not created yet), the runner hardcodes SQLite even though `DB_TYPE` supports MySQL, and nothing is transactional, so a migration that fails halfway leaves the schema partly changed and unrecorded.

Separately, `CMD ["sh", "-c", "... && python app/main.py"]` leaves the shell as PID 1, so `docker stop` never reaches the bot.

## Changes

- **migrations refactor:** a `MigrationContext` owns the connection, picks the migrator for `DB_TYPE`, and exposes idempotent operations. All 19 migrations become a docstring plus one `upgrade(ctx)`, 604 lines down to 296. Each migration and its `schema_migrations` row share a transaction. Adds `--status`.
- **pre-migration backup:** snapshot before applying anything, only when something is pending, aborting the run if it fails. Reuses the WAL-safe snapshot from #172, now shared between the runner and the bot.
- **docker exec:** one word, so the bot is PID 1 and receives SIGTERM.
- **sigterm handling:** close the bot on SIGTERM instead of being SIGKILLed after the grace period.

## Verified

- replayed all 19 migrations against a copy of prod with old and new code: identical DDL, columns and per-table checksums, and identical to untouched prod, so a full replay changes nothing
- against a synthetic pre-001 schema, which exercises the transformations rather than the guards: identical apart from cosmetic DDL text in the three tables that previously used raw SQL
- `docker stop` measured before and after: 11s then SIGKILL, vs instant clean exit
- 13 tests pass, 9 of them new. `test_bot.py` and two async backup tests cannot run in my environment (`pytest_asyncio` and `elasticapm` missing), so `main.py` is compile-checked only and its shutdown path was validated separately in a container.

## Note

Run `poetry install` once to refresh the console script: the entry point moved to `migrate:main` for argument parsing.
