### PR TITLE
fix(fixit): skip issues when the configured channel is unavailable

### DIFF
--- a/app/cogs/fixit/fixit.py
+++ b/app/cogs/fixit/fixit.py
@@ -62,13 +62,19 @@ class FixIt(LancoCog, name="FixIt", description="FixIt issue tracking"):
                 ):
                     continue
 
+                channel = self.bot.get_channel(fixit_config.channel_id)
+                if channel is None:
+                    self.logger.warning(
+                        f"Channel {fixit_config.channel_id} not found, skipping issue {issue.id}"
+                    )
+                    continue
+
                 self.logger.info(f"New FixIt issue: {issue.id} - {issue.summary}")
+
+                await self.share_issue(issue, channel)
 
                 fixit_config.last_known_issue = issue.id
                 fixit_config.save()
-
-                channel = self.bot.get_channel(fixit_config.channel_id)
-                await self.share_issue(issue, channel)
 
     @g.command(
         name="subscribe",


### PR DESCRIPTION
## Problem

`get_new_issues` passed `bot.get_channel()` straight into `share_issue` without a null
check, so a subscription pointing at an unreachable channel raised
`'NoneType' object has no attribute 'send'` on every poll. `last_known_issue` was saved
before the send, so those issues were marked seen and silently dropped for good.

## Changes

- **fixit:** warn and skip when the channel isn't found, matching `incidents`
- **fixit:** save `last_known_issue` only after the post succeeds

## Verified

`poetry run test`: 21 passed. Not re-run in dev to watch the new skip path.
