### PR TITLE
refactor(cogs): create tables in cog_load instead of __init__

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,3 +175,4 @@ COG_AUDIT.md
 # local scratch notes, not part of the repo
 JOURNAL.md
 STATUS.md
+*_FINDINGS.md

--- a/app/cogs/TruthSocial/TruthSocial.py
+++ b/app/cogs/TruthSocial/TruthSocial.py
@@ -45,12 +45,15 @@ class TruthSocial(
             username=os.getenv("TRUTH_SOCIAL_USERNAME"),
             password=os.getenv("TRUTH_SOCIAL_PASSWORD"),
         )
-        self.bot.database.create_tables([TruthSocialEmbedConfig])
         self.avatar_cache_dir = os.path.join(
             self.get_cog_data_directory(), "AvatarCache"
         )
         self.media_cache_dir = os.path.join(self.get_cog_data_directory(), "MediaCache")
         self.file_downloader = FileDownloader()
+
+    async def cog_load(self):
+        await super().cog_load()
+        self.bot.database.create_tables([TruthSocialEmbedConfig])
 
     @track_message_ids()
     @commands.Cog.listener()

--- a/app/cogs/aiprompts/aiprompts.py
+++ b/app/cogs/aiprompts/aiprompts.py
@@ -73,8 +73,11 @@ class OpenAIPrompts(
     def __init__(self, bot: commands.Bot):
         super().__init__(bot)
         self.client = AsyncOpenAI(api_key=os.getenv("OPENAI_API_KEY"))
-        self.bot.database.create_tables([AIPromptConfig])
         self.custom_agents: dict[int, Agent] = {}  # AI ID -> Agent
+
+    async def cog_load(self):
+        await super().cog_load()
+        self.bot.database.create_tables([AIPromptConfig])
 
     def get_agent(self, AIpromptConfig: AIPromptConfig) -> Agent:
         ai_id = AIpromptConfig.id

--- a/app/cogs/animetoday/animetoday.py
+++ b/app/cogs/animetoday/animetoday.py
@@ -23,6 +23,9 @@ class AnimeToday(
 
     def __init__(self, bot: commands.Bot):
         super().__init__(bot)
+
+    async def cog_load(self):
+        await super().cog_load()
         self.bot.database.create_tables([AnimeTodayConfig])
         self.daily_anime_task.start()
 

--- a/app/cogs/autoreact/autoreact.py
+++ b/app/cogs/autoreact/autoreact.py
@@ -19,6 +19,9 @@ class AutoReact(
 
     def __init__(self, bot: commands.Bot):
         super().__init__(bot)
+
+    async def cog_load(self):
+        await super().cog_load()
         self.bot.database.create_tables([AutoReactConfig])
 
     @g.command(name="add", description="Set an auto-react response")

--- a/app/cogs/autoresponse/autoresponse.py
+++ b/app/cogs/autoresponse/autoresponse.py
@@ -19,6 +19,9 @@ class AutoResponse(
 
     def __init__(self, bot: commands.Bot):
         super().__init__(bot)
+
+    async def cog_load(self):
+        await super().cog_load()
         self.bot.database.create_tables([AutoResponseConfig])
 
     @g.command(name="add", description="Set an auto-response")

--- a/app/cogs/barhopper/barhopper.py
+++ b/app/cogs/barhopper/barhopper.py
@@ -28,11 +28,14 @@ class BarHopper(LancoCog, name="BarHopper", description="Bar hopper commands"):
 
     def __init__(self, bot: commands.Bot):
         super().__init__(bot)
-        self.bot.database.create_tables([Bar])
         self.gmaps = googlemaps.Client(key=os.getenv("GMAPS_API_KEY"))
         self.bar_details_cache = cachetools.TTLCache(
             maxsize=100, ttl=60 * 60 * 24
         )  # 24 hours
+
+    async def cog_load(self):
+        await super().cog_load()
+        self.bot.database.create_tables([Bar])
 
     @barhopper_group.command(
         name="populate", description="Populate the database with bars"

--- a/app/cogs/birthday/birthday.py
+++ b/app/cogs/birthday/birthday.py
@@ -53,6 +53,9 @@ class Birthday(LancoCog, name="Birthday", description="Wish a user a happy birth
 
     def __init__(self, bot: commands.Bot):
         super().__init__(bot)
+
+    async def cog_load(self):
+        await super().cog_load()
         self.bot.database.create_tables([BirthdayUser, BirthdayAnnouncementConfig])
         self.daily_bday_task.start()
 

--- a/app/cogs/captcha/captcha.py
+++ b/app/cogs/captcha/captcha.py
@@ -48,10 +48,10 @@ class CaptchaCog(
     def __init__(self, bot: commands.Bot):
         super().__init__(bot)
         self._ready_at: float = 0.0
-        self.bot.database.create_tables([RoundGameResult])
 
     async def cog_load(self):
         await super().cog_load()
+        self.bot.database.create_tables([RoundGameResult])
         self._ready_at = time.time()
 
     @property

--- a/app/cogs/commands/commands.py
+++ b/app/cogs/commands/commands.py
@@ -181,12 +181,15 @@ class Commands(LancoCog, name="Commands", description="Custom guild commands"):
 
     def __init__(self, bot: commands.Bot):
         super().__init__(bot)
-        self.bot.database.create_tables([CustomCommands])
         self.agent = Agent(
             model="openai:gpt-5-nano",
             system_prompt="Generate a concise and relevant response based on the user's command prompt.",
             output_type=AICommandResponse,
         )
+
+    async def cog_load(self):
+        await super().cog_load()
+        self.bot.database.create_tables([CustomCommands])
 
     @commands_group.command(name="create", description="Create a custom command")
     @is_bot_owner_or_admin()

--- a/app/cogs/common/embedfixcog.py
+++ b/app/cogs/common/embedfixcog.py
@@ -141,8 +141,11 @@ class EmbedFixCog(LancoCog, name="EmbedFixCog", description="Abstract embed fix 
         self.config_model = config_model
         self.skip_if_handled_by_discord = skip_if_handled_by_discord
         self.wait_time = wait_time
-        self.bot.database.create_tables([self.config_model])
         self.fixed_messages = LRUCache(maxsize=1000)  # message_id -> fixed_message_id
+
+    async def cog_load(self):
+        await super().cog_load()
+        self.bot.database.create_tables([self.config_model])
 
     def _active_handler(self, config) -> "EmbedFixCog.Handler":
         """Return the configured Handler for this guild, falling back to the first."""

--- a/app/cogs/dadjoke/dadjoke.py
+++ b/app/cogs/dadjoke/dadjoke.py
@@ -26,6 +26,9 @@ class dadjoke(
 
     def __init__(self, bot):
         super().__init__(bot)
+
+    async def cog_load(self):
+        await super().cog_load()
         self.bot.database.create_tables([DadJokeConfig])
 
     @g.command(name="toggle", description="Toggle dad jokes")

--- a/app/cogs/everbridge/everbridge.py
+++ b/app/cogs/everbridge/everbridge.py
@@ -38,10 +38,11 @@ class Everbridge(
             username=os.getenv("EVERBRIDGE_USERNAME"),
             password=os.getenv("EVERBRIDGE_PASSWORD"),
         )
-        self.bot.database.create_tables([EverbridgeConfig])
         self._warned_channels: set[int] = set()
 
     async def cog_load(self):
+        await super().cog_load()
+        self.bot.database.create_tables([EverbridgeConfig])
         self.poll.start()
 
     def cog_unload(self):

--- a/app/cogs/facts/facts.py
+++ b/app/cogs/facts/facts.py
@@ -52,6 +52,9 @@ class Facts(
 
     def __init__(self, bot: commands.Bot):
         super().__init__(bot)
+
+    async def cog_load(self):
+        await super().cog_load()
         self.bot.database.create_tables([Fact])
 
     def get_random_fact(self, guild_id: int = None) -> Fact:

--- a/app/cogs/filefixer/filefixer.py
+++ b/app/cogs/filefixer/filefixer.py
@@ -20,8 +20,11 @@ class FileFixer(LancoCog, name="FileFixer", description="Attempt to fix files"):
     def __init__(self, bot: commands.Bot):
         super().__init__(bot)
         self.cache_dir = os.path.join(self.get_cog_data_directory(), "Cache")
-        self.bot.database.create_tables([FileFixerConfig])
         self.file_downloader = FileDownloader()
+
+    async def cog_load(self):
+        await super().cog_load()
+        self.bot.database.create_tables([FileFixerConfig])
 
     @g.command(
         name="toggle", description="Toggle support for fixing unsupported file types"

--- a/app/cogs/fishbowl/fishbowl.py
+++ b/app/cogs/fishbowl/fishbowl.py
@@ -16,6 +16,9 @@ class Fishbowl(
 
     def __init__(self, bot: commands.Bot):
         super().__init__(bot)
+
+    async def cog_load(self):
+        await super().cog_load()
         self.bot.database.create_tables([FishbowlConfig])
 
     @commands.Cog.listener()

--- a/app/cogs/fixit/fixit.py
+++ b/app/cogs/fixit/fixit.py
@@ -19,10 +19,11 @@ class FixIt(LancoCog, name="FixIt", description="FixIt issue tracking"):
 
     def __init__(self, bot: commands.Bot):
         super().__init__(bot)
-        self.bot.database.create_tables([FixItConfig])
         self.client = SeeClickFixClient()
 
     async def cog_load(self):
+        await super().cog_load()
+        self.bot.database.create_tables([FixItConfig])
         self.poll.start()
 
     def cog_unload(self):

--- a/app/cogs/geoguesser/geoguesser.py
+++ b/app/cogs/geoguesser/geoguesser.py
@@ -66,11 +66,11 @@ class GeoGuesser(
         self.gmaps = None
         self.location_utils = None
         self._ready_at: float = 0.0
-        self.bot.database.create_tables([LocationModel, RoundGameResult])
         _sessions_starting.clear()
 
     async def cog_load(self):
         await super().cog_load()
+        self.bot.database.create_tables([LocationModel, RoundGameResult])
         self._ready_at = time.time()
         api_key = os.getenv("GMAPS_API_KEY")
         if not api_key:

--- a/app/cogs/incidents/incidents.py
+++ b/app/cogs/incidents/incidents.py
@@ -46,7 +46,6 @@ class Incidents(LancoCog, name="Incidents", description="LCWC Incident feed"):
 
     def __init__(self, bot: commands.Bot):
         super().__init__(bot)
-        self.bot.database.create_tables([IncidentsGlobalConfig, IncidentConfig])
 
         gmaps = googlemaps.Client(key=os.getenv("GMAPS_API_KEY"))
         self.geocoder = IncidentGeocoder(gmaps)
@@ -61,15 +60,8 @@ class Incidents(LancoCog, name="Incidents", description="LCWC Incident feed"):
         ]
         self._client_priority = [self.arcgis_client, self.feed_client, self.web_client]
 
-        client_config = IncidentsGlobalConfig.get_or_none(
-            IncidentsGlobalConfig.name == "client"
-        )
-        if client_config:
-            self.logger.info(f"Found global config: {client_config.value}")
-            self.set_client_from_name(client_config.value)
-        else:
-            self.current_client = self.arcgis_client
-
+        # Default until cog_load reads the persisted override from the database
+        self.current_client = self.arcgis_client
         self.preferred_client = self.current_client
         self.auto_switched = False
         self.consecutive_failures = 0
@@ -80,6 +72,16 @@ class Incidents(LancoCog, name="Incidents", description="LCWC Incident feed"):
 
     async def cog_load(self):
         await super().cog_load()
+        self.bot.database.create_tables([IncidentsGlobalConfig, IncidentConfig])
+
+        client_config = IncidentsGlobalConfig.get_or_none(
+            IncidentsGlobalConfig.name == "client"
+        )
+        if client_config:
+            self.logger.info(f"Found global config: {client_config.value}")
+            self.set_client_from_name(client_config.value)
+        self.preferred_client = self.current_client
+
         self.get_incidents_loop.change_interval(seconds=5)
         self.get_incidents_loop.start()
         self.recovery_check_loop.start()

--- a/app/cogs/paywallbypass/paywallbypass.py
+++ b/app/cogs/paywallbypass/paywallbypass.py
@@ -54,8 +54,12 @@ class PaywallBypass(EmbedFixCog, name="Paywall Bypass", description="Bypass payw
 
     def __init__(self, bot: commands.Bot):
         super().__init__(bot, "Paywall Bypass", _HANDLERS, PaywallBypassConfig)
-        self.bot.database.create_tables([PaywallPattern])
         self._pattern_cache: dict[int, set[str]] = {}
+
+    async def cog_load(self):
+        # EmbedFixCog.cog_load creates PaywallBypassConfig, our shared base table
+        await super().cog_load()
+        self.bot.database.create_tables([PaywallPattern])
 
     def _guild_patterns(self, guild_id: int) -> set[str]:
         if guild_id not in self._pattern_cache:

--- a/app/cogs/pdfpreview/pdfpreview.py
+++ b/app/cogs/pdfpreview/pdfpreview.py
@@ -28,10 +28,10 @@ class PDFPreview(
         self.virus_check = VirusCheck(os.getenv("VIRUS_TOTAL_API_KEY"))
         if not os.path.exists(self.previews_path):
             os.makedirs(self.previews_path)
-        self.bot.database.create_tables([PDFPreviewConfig])
 
     async def cog_load(self):
         await super().cog_load()
+        self.bot.database.create_tables([PDFPreviewConfig])
         # A file intent: any .pdf attachment or link in an enabled guild. The
         # router downloads it once and hands us the local path + bytes.
         self.register_file_intent(

--- a/app/cogs/pinboard/pinboard.py
+++ b/app/cogs/pinboard/pinboard.py
@@ -19,6 +19,9 @@ class Pinboard(
         self.register_context_menu(
             name="Pin Message", callback=self.ctx_menu, errback=self.ctx_menu_error
         )
+
+    async def cog_load(self):
+        await super().cog_load()
         self.bot.database.create_tables([PinboardPost])
 
     async def ctx_menu(

--- a/app/cogs/profile/profile.py
+++ b/app/cogs/profile/profile.py
@@ -72,6 +72,9 @@ class UserProfiles(LancoCog, name="UserProfiles", description="Custom user profi
 
     def __init__(self, bot: commands.Bot):
         super().__init__(bot)
+
+    async def cog_load(self):
+        await super().cog_load()
         self.bot.database.create_tables([UserProfile, ProfileLink, UserProfilesConfig])
 
     @profiles_group.command(

--- a/app/cogs/reacttrack/reacttrack.py
+++ b/app/cogs/reacttrack/reacttrack.py
@@ -16,6 +16,9 @@ class ReactTrack(
 
     def __init__(self, bot: commands.Bot):
         super().__init__(bot)
+
+    async def cog_load(self):
+        await super().cog_load()
         self.bot.database.create_tables([ReactEvent])
 
     @commands.Cog.listener()

--- a/app/cogs/redditfeed/redditfeed.py
+++ b/app/cogs/redditfeed/redditfeed.py
@@ -50,7 +50,6 @@ class RedditFeed(LancoCog, name="RedditFeed", description="Reddit feed polling")
 
     def __init__(self, bot: commands.Bot):
         super().__init__(bot)
-        self.bot.database.create_tables([RedditFeedConfig, RedditPost])
         self.reddit = asyncpraw.Reddit(
             client_id=os.getenv("REDDIT_ID"),
             client_secret=os.getenv("REDDIT_SECRET"),
@@ -67,6 +66,8 @@ class RedditFeed(LancoCog, name="RedditFeed", description="Reddit feed polling")
         self._seen_ids_loaded: set[str] = set()  # subreddits whose DB rows are loaded
 
     async def cog_load(self):
+        await super().cog_load()
+        self.bot.database.create_tables([RedditFeedConfig, RedditPost])
         self.poll.start()
         self.check_post_states.start()
 

--- a/app/cogs/rssfeed/rssfeed.py
+++ b/app/cogs/rssfeed/rssfeed.py
@@ -24,13 +24,14 @@ class RssFeed(
 
     def __init__(self, bot: commands.Bot):
         super().__init__(bot)
-        self.bot.database.create_tables([RSSFeedConfig])
         self._warned_channels: set[int] = set()
         # feed urls already warned about, so a persistently broken feed does not
         # emit a warning on every poll
         self._warned_feeds: set[str] = set()
 
     async def cog_load(self):
+        await super().cog_load()
+        self.bot.database.create_tables([RSSFeedConfig])
         self.poll.start()
 
     def cog_unload(self):

--- a/app/cogs/spotifyembed/spotifyembed.py
+++ b/app/cogs/spotifyembed/spotifyembed.py
@@ -31,7 +31,6 @@ class SpotifyEmbed(
             client_secret=os.getenv("SPOTIFY_SECRET"),
         )
         self.sp = spotipy.Spotify(client_credentials_manager=creds)
-        self.bot.database.create_tables([SpotifyEmbedConfig])
         self.fixed_messages = LRUCache(maxsize=1000)  # message_id -> fixed_message_id
 
         bot.register_url_handler(
@@ -41,6 +40,10 @@ class SpotifyEmbed(
                 example_url="https://open.spotify.com/playlist/7q7fMqxIWb8LBCHnyhvxBt",
             )
         )
+
+    async def cog_load(self):
+        await super().cog_load()
+        self.bot.database.create_tables([SpotifyEmbedConfig])
 
     @commands.Cog.listener()
     async def on_message(self, message):

--- a/app/cogs/transcribe/transcribe.py
+++ b/app/cogs/transcribe/transcribe.py
@@ -22,11 +22,14 @@ class Transcribe(
     def __init__(self, bot: commands.Bot):
         super().__init__(bot)
         self.cache_dir = os.path.join(self.get_cog_data_directory(), "Cache")
-        self.bot.database.create_tables([TranscribeConfig])
         self.model = whisper.load_model("base", device="cpu")
         self.register_context_menu(
             name="Transcribe", callback=self.ctx_menu, errback=self.ctx_menu_error
         )
+
+    async def cog_load(self):
+        await super().cog_load()
+        self.bot.database.create_tables([TranscribeConfig])
 
     async def ctx_menu(
         self, interaction: discord.Interaction, message: discord.Message

--- a/app/cogs/verification/verification.py
+++ b/app/cogs/verification/verification.py
@@ -27,6 +27,9 @@ class Verification(
 
     def __init__(self, bot):
         super().__init__(bot)
+
+    async def cog_load(self):
+        await super().cog_load()
         self.bot.database.create_tables([VerificationConfig, VerificationRequest])
 
     @g.command(name="threshold", description="Set the vote threshold.")

--- a/app/cogs/webpreview/webpreview.py
+++ b/app/cogs/webpreview/webpreview.py
@@ -27,6 +27,9 @@ class WebPreview(
 
     def __init__(self, bot: commands.Bot):
         super().__init__(bot)
+
+    async def cog_load(self):
+        await super().cog_load()
         self.bot.database.create_tables([WebPreviewConfig])
 
     @commands.Cog.listener()

--- a/app/cogs/youtube/youtube.py
+++ b/app/cogs/youtube/youtube.py
@@ -33,9 +33,10 @@ class Youtube(
     def __init__(self, bot: commands.Bot):
         super().__init__(bot)
         self.google = Aiogoogle(api_key=os.getenv("YOUTUBE_API_KEY"))
-        self.bot.database.create_tables([YoutubeSubscription])
 
     async def cog_load(self):
+        await super().cog_load()
+        self.bot.database.create_tables([YoutubeSubscription])
         self.poll.start()
 
     def cog_unload(self):


### PR DESCRIPTION
## Problem

Table creation belongs in `cog_load`, but 30 of 35 call sites did it in `__init__`, which blocks on disk I/O during import and repeats on every hot-reload.

`incidents` also read `IncidentsGlobalConfig` in the same constructor and only assigned `current_client` in that read's `else` branch, so a stored name matching no client left the attribute unset.

## Changes

- **cogs:** move all 30 `create_tables` calls to `cog_load`
- **incidents:** move the config read to `cog_load` and default `current_client` in `__init__`
- **embedfixcog:** create `config_model` in the base `cog_load`, covering all six subclasses
- **animetoday, birthday:** move `tasks.loop.start()` down with it, so loops can't run before their tables exist
- **everbridge, fixit, redditfeed, rssfeed, youtube:** add the missing `await super().cog_load()`
- **repo:** ignore local findings documents

## Verified

`poetry run test`: 30 passed. Cog loading compared before and after: 58 loaded, 17 errored, same cogs both times. Not run in dev.

Cogs that fail to construct no longer create tables as a side effect. Only visible without API keys; `migrations/helpers.py` guards on missing tables anyway.
