### PR TITLE
feat(webserver): start automatically and split health from status

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -47,6 +47,9 @@ DATABASE_BACKUP_RETENTION=7
 MESSAGE_CACHE_SIZE=1000
 # Enable development mode (set automatically by poetry run dev)
 DEV_MODE=false
+# Port for the embedded web server, which starts with the webserver cog and
+# serves /status. Blacklist the cog to disable it entirely.
+WEBSERVER_PORT=8080
 
 # =========================
 # Logging

--- a/.env.default
+++ b/.env.default
@@ -48,8 +48,11 @@ MESSAGE_CACHE_SIZE=1000
 # Enable development mode (set automatically by poetry run dev)
 DEV_MODE=false
 # Port for the embedded web server, which starts with the webserver cog and
-# serves /status. Blacklist the cog to disable it entirely.
+# serves /health. Blacklist the cog to disable it entirely.
 WEBSERVER_PORT=8080
+# Bearer token guarding the detailed /status endpoint. Leave empty to keep
+# /status disabled; /health is always public and exposes nothing sensitive.
+WEBSERVER_TOKEN=
 
 # =========================
 # Logging

--- a/app/cogs/webserver/README.md
+++ b/app/cogs/webserver/README.md
@@ -27,7 +27,8 @@ signal: `200` once the gateway is connected, `503` before that.
 ### `GET /status`
 
 Detailed status. Requires `Authorization: Bearer $WEBSERVER_TOKEN` and returns
-`401` without it, or `503` when no token is configured.
+`401` without it, or `503` when no token is configured. Every field is read from
+memory, so a request makes no Discord API calls and does no I/O.
 
 ```bash
 curl -H "Authorization: Bearer $WEBSERVER_TOKEN" http://host:8080/status
@@ -47,6 +48,9 @@ curl -H "Authorization: Bearer $WEBSERVER_TOKEN" http://host:8080/status
   "cogs_failed": ["transcribe"],
   "message_cache": 1000,
   "url_handlers": 6,
+  "emojis": 214,
+  "stickers": 12,
+  "voice_clients": 0,
   "dev_mode": false,
   "version": "0.1.0",
   "commit": "68826df",

--- a/app/cogs/webserver/README.md
+++ b/app/cogs/webserver/README.md
@@ -1,6 +1,6 @@
 # WebServer
 
-Runs an embedded aiohttp web server exposing a bot status endpoint.
+Runs an embedded aiohttp web server exposing bot health and status endpoints.
 
 The server starts automatically when the cog loads and stops when it unloads. To
 disable it, add `webserver` to `COG_BLACKLIST`.
@@ -9,17 +9,54 @@ disable it, add `webserver` to `COG_BLACKLIST`.
 
 | Variable | Default | Description |
 |---|---|---|
-| `WEBSERVER_PORT` | `8080` | Port to bind on. Bound on `0.0.0.0` so it is reachable from outside the container. |
+| `WEBSERVER_PORT` | `8080` | Port to bind on. Bound on `0.0.0.0` and published by `docker-compose.yml`. |
+| `WEBSERVER_TOKEN` | unset | Bearer token guarding `/status`. While unset, `/status` stays disabled. |
 
 ## Endpoints
 
-| Endpoint | Description |
-|---|---|
-| `GET /status` | Bot status as JSON. Returns 503 until the gateway connection is ready. |
+### `GET /health`
 
-Nothing publishes the port to the host by default. Add a `ports:` mapping in
-`docker-compose.yml` if the endpoint needs to be reachable from outside the
-container, keeping in mind `/status` is unauthenticated.
+Unauthenticated liveness probe for uptime monitors. Makes no Discord API calls,
+so it cannot be used to burn the bot's REST rate limit. The status code is the
+signal: `200` once the gateway is connected, `503` before that.
+
+```json
+{ "status": "ok", "uptime_seconds": 84213, "latency_ms": 42 }
+```
+
+### `GET /status`
+
+Detailed status. Requires `Authorization: Bearer $WEBSERVER_TOKEN` and returns
+`401` without it, or `503` when no token is configured.
+
+```bash
+curl -H "Authorization: Bearer $WEBSERVER_TOKEN" http://host:8080/status
+```
+
+```json
+{
+  "status": "ok",
+  "ready": true,
+  "uptime_seconds": 84213,
+  "latency_ms": 42,
+  "guilds": 7,
+  "cached_users": 1243,
+  "commands": 33,
+  "slash_commands": 47,
+  "cogs_loaded": 58,
+  "cogs_failed": ["transcribe"],
+  "message_cache": 1000,
+  "url_handlers": 6,
+  "dev_mode": false,
+  "version": "0.1.0",
+  "commit": "68826df",
+  "python_version": "3.10.11",
+  "discordpy_version": "2.7.1"
+}
+```
+
+`cogs_failed` lists cogs that raised during load, which is otherwise only
+visible in the logs at startup.
 
 ## Commands
 

--- a/app/cogs/webserver/README.md
+++ b/app/cogs/webserver/README.md
@@ -2,6 +2,25 @@
 
 Runs an embedded aiohttp web server exposing a bot status endpoint.
 
+The server starts automatically when the cog loads and stops when it unloads. To
+disable it, add `webserver` to `COG_BLACKLIST`.
+
+## Configuration
+
+| Variable | Default | Description |
+|---|---|---|
+| `WEBSERVER_PORT` | `8080` | Port to bind on. Bound on `0.0.0.0` so it is reachable from outside the container. |
+
+## Endpoints
+
+| Endpoint | Description |
+|---|---|
+| `GET /status` | Bot status as JSON. Returns 503 until the gateway connection is ready. |
+
+Nothing publishes the port to the host by default. Add a `ports:` mapping in
+`docker-compose.yml` if the endpoint needs to be reachable from outside the
+container, keeping in mind `/status` is unauthenticated.
+
 ## Commands
 
 | Command | Description | Permissions |

--- a/app/cogs/webserver/webserver.py
+++ b/app/cogs/webserver/webserver.py
@@ -6,7 +6,9 @@ WebServer cog
 """
 
 import datetime
+import math
 import os
+import secrets
 from sys import version_info as sysv
 
 import discord
@@ -45,43 +47,78 @@ class WebServer(
         # replacement cog fails to bind.
         await self.stop_webserver()
 
+    def _uptime_seconds(self) -> int:
+        return int((datetime.datetime.now() - self.bot.start_time).total_seconds())
+
+    def _latency_ms(self) -> int | None:
+        # Latency is nan until the first heartbeat, which is not valid JSON for
+        # strict parsers, so report null instead.
+        latency = self.bot.latency
+        if math.isnan(latency):
+            return None
+        return round(latency * 1000)
+
+    async def handle_health(self, request: web.Request) -> web.Response:
+        """Unauthenticated liveness probe.
+
+        Deliberately cheap: no Discord API calls, so hammering it cannot burn
+        the bot's REST rate limit. The status code is the signal, 200 once the
+        gateway is connected and 503 before that.
+        """
+        ready = self.bot.is_ready()
+        return web.json_response(
+            {
+                "status": "ok" if ready else "starting",
+                "uptime_seconds": self._uptime_seconds(),
+                "latency_ms": self._latency_ms(),
+            },
+            status=200 if ready else 503,
+        )
+
+    def _token_matches(self, request: web.Request, token: str) -> bool:
+        scheme, _, value = request.headers.get("Authorization", "").partition(" ")
+        if scheme.lower() != "bearer":
+            return False
+        return secrets.compare_digest(value, token)
+
     async def handle_status(self, request: web.Request) -> web.Response:
-        """Handle the /status endpoint"""
+        """Detailed status, gated behind WEBSERVER_TOKEN.
 
-        if not self.bot.is_ready():
-            return web.json_response({"Status": "Starting"}, status=503)
+        Fails closed: with no token configured the endpoint stays off rather
+        than publishing this to anyone who finds the port.
+        """
+        token = os.getenv("WEBSERVER_TOKEN", "")
+        if not token:
+            return web.json_response(
+                {"error": "WEBSERVER_TOKEN is not set, /status is disabled"},
+                status=503,
+            )
+        if not self._token_matches(request, token):
+            return web.json_response({"error": "unauthorized"}, status=401)
 
-        info = await self.bot.application_info()
-        application_emojis = await self.bot.fetch_application_emojis()
-
-        commit = get_commit_hash()
-
-        uptime = datetime.datetime.now() - self.bot.start_time
-        owner = self.bot.get_user(info.owner.id)
-        dict = {
-            "Status": "OK",
-            "Python Version": f"{sysv.major}.{sysv.minor}.{sysv.micro}",
-            "Discord.py Version": f"{discord.__version__}",
-            "Guilds": len(self.bot.guilds),
-            "Users": len(self.bot.users),
-            "Commands": len(self.bot.commands),
-            "Slash Commands": len(self.bot.tree.get_commands()),
-            "Latency": f"{round(self.bot.latency * 1000)}ms",
-            "Dev Mode": f"{'Enabled' if self.bot.dev_mode else 'Disabled'}",
-            "Uptime": f"{uptime.days}d {uptime.seconds // 3600}h {(uptime.seconds // 60) % 60}m {uptime.seconds % 60}s",
-            "Cogs": len(self.bot.get_lanco_cogs()),
-            "Owner": f"{owner.mention if owner else info.owner.global_name}",
-            "Commit": commit[:7],
-            "Message Cache": len(self.bot.cached_messages),
-            "Voice Clients": len(self.bot.voice_clients),
-            "Emojis": len(self.bot.emojis),
-            "App Emojis": len(application_emojis),
-            "Stickers": len(self.bot.stickers),
-            "URL Handlers": len(self.bot.url_handlers),
-            "Version": f"{get_bot_version()}",
-        }
-
-        return web.json_response(dict)
+        ready = self.bot.is_ready()
+        return web.json_response(
+            {
+                "status": "ok" if ready else "starting",
+                "ready": ready,
+                "uptime_seconds": self._uptime_seconds(),
+                "latency_ms": self._latency_ms(),
+                "guilds": len(self.bot.guilds),
+                # Cache size, not a real user count
+                "cached_users": len(self.bot.users),
+                "commands": len(self.bot.commands),
+                "slash_commands": len(self.bot.tree.get_commands()),
+                "cogs_loaded": len(self.bot.extensions),
+                "cogs_failed": sorted(getattr(self.bot, "failed_cogs", {})),
+                "message_cache": len(self.bot.cached_messages),
+                "url_handlers": len(self.bot.url_handlers),
+                "dev_mode": self.bot.dev_mode,
+                "version": get_bot_version(),
+                "commit": (get_commit_hash() or "unknown")[:7],
+                "python_version": f"{sysv.major}.{sysv.minor}.{sysv.micro}",
+                "discordpy_version": discord.__version__,
+            }
+        )
 
     @property
     def running(self) -> bool:
@@ -94,6 +131,7 @@ class WebServer(
             return False
 
         app = web.Application()
+        app.router.add_get("/health", self.handle_health)
         app.router.add_get("/status", self.handle_status)
         runner = web.AppRunner(app)
         await runner.setup()

--- a/app/cogs/webserver/webserver.py
+++ b/app/cogs/webserver/webserver.py
@@ -84,8 +84,8 @@ class WebServer(
     async def handle_status(self, request: web.Request) -> web.Response:
         """Detailed status, gated behind WEBSERVER_TOKEN.
 
-        Fails closed: with no token configured the endpoint stays off rather
-        than publishing this to anyone who finds the port.
+        Fails closed: with no token configured the endpoint stays disabled.
+        Every field is read from memory, so a request costs nothing.
         """
         token = os.getenv("WEBSERVER_TOKEN", "")
         if not token:
@@ -112,6 +112,13 @@ class WebServer(
                 "cogs_failed": sorted(getattr(self.bot, "failed_cogs", {})),
                 "message_cache": len(self.bot.cached_messages),
                 "url_handlers": len(self.bot.url_handlers),
+                # Guild emojis and stickers come from the local cache. The
+                # application emoji count is deliberately absent: it is the only
+                # one needing a REST call, and caching it would just serve a
+                # stale number for a metric nothing acts on.
+                "emojis": len(self.bot.emojis),
+                "stickers": len(self.bot.stickers),
+                "voice_clients": len(self.bot.voice_clients),
                 "dev_mode": self.bot.dev_mode,
                 "version": get_bot_version(),
                 "commit": (get_commit_hash() or "unknown")[:7],

--- a/app/cogs/webserver/webserver.py
+++ b/app/cogs/webserver/webserver.py
@@ -23,19 +23,33 @@ class WebServer(
     name="webserver",
     description="Embedded HTTP server for bot integrations",
 ):
-    PORT = 6969
+    DEFAULT_PORT = 8080
 
     g = app_commands.Group(name="web", description="Webserver commands")
 
     def __init__(self, bot):
         super().__init__(bot)
+        self.port = int(os.getenv("WEBSERVER_PORT", self.DEFAULT_PORT))
+        self._runner: web.AppRunner | None = None
 
-    async def on_ready(self):
-        """Called when the bot is ready"""
+    async def cog_load(self):
+        await super().cog_load()
+        # Binding a socket needs no gateway connection, so start here rather than
+        # from on_ready: cog_load also covers a hot-reload, where the bot is
+        # already ready and on_ready will not fire again.
         await self.start_webserver()
+
+    async def cog_unload(self):
+        await super().cog_unload()
+        # Without this a reload leaves the old runner holding the port, and the
+        # replacement cog fails to bind.
+        await self.stop_webserver()
 
     async def handle_status(self, request: web.Request) -> web.Response:
         """Handle the /status endpoint"""
+
+        if not self.bot.is_ready():
+            return web.json_response({"Status": "Starting"}, status=503)
 
         info = await self.bot.application_info()
         application_emojis = await self.bot.fetch_application_emojis()
@@ -69,23 +83,45 @@ class WebServer(
 
         return web.json_response(dict)
 
-    async def start_webserver(self):
+    @property
+    def running(self) -> bool:
+        return self._runner is not None
+
+    async def start_webserver(self) -> bool:
+        """Start the server. Returns False if it was already running."""
+        if self.running:
+            self.logger.debug(f"Webserver already running on port {self.port}")
+            return False
+
         app = web.Application()
         app.router.add_get("/status", self.handle_status)
         runner = web.AppRunner(app)
         await runner.setup()
-        site = web.TCPSite(runner, "0.0.0.0", self.PORT)
-        await site.start()
-        self.logger.info(f"Webserver started on port {self.PORT}")
+        try:
+            await web.TCPSite(runner, "0.0.0.0", self.port).start()
+        except OSError as e:
+            # Most often the port is already taken by another process
+            await runner.cleanup()
+            self.logger.error(f"Failed to start webserver on port {self.port}: {e}")
+            return False
 
-    async def stop_webserver(self):
-        app = web.Application()
-        runner = web.AppRunner(app)
-        await runner.cleanup()
+        self._runner = runner
+        self.logger.info(f"Webserver started on port {self.port}")
+        return True
 
-    async def restart_webserver(self):
+    async def stop_webserver(self) -> bool:
+        """Stop the server. Returns False if it was not running."""
+        if not self.running:
+            return False
+        # cleanup() shuts down the site and its sockets along with the runner
+        await self._runner.cleanup()
+        self._runner = None
+        self.logger.info("Webserver stopped")
+        return True
+
+    async def restart_webserver(self) -> bool:
         await self.stop_webserver()
-        await self.start_webserver()
+        return await self.start_webserver()
 
     @is_bot_owner()
     @g.command(
@@ -95,11 +131,15 @@ class WebServer(
     async def start_webserver_command(self, interaction: discord.Interaction):
         """Start the webserver"""
         await interaction.response.send_message("Starting webserver...", ephemeral=True)
-        await self.start_webserver()
+        started = await self.start_webserver()
         embed = discord.Embed(
-            title="Webserver started",
-            description=f"Webserver started on port {self.PORT}",
-            color=discord.Color.green(),
+            title="Webserver started" if started else "Webserver not started",
+            description=(
+                f"Webserver started on port {self.port}"
+                if started
+                else f"Already running on port {self.port}, or the port is unavailable"
+            ),
+            color=discord.Color.green() if started else discord.Color.orange(),
         )
         await interaction.followup.send(embed=embed, ephemeral=True)
 
@@ -111,11 +151,13 @@ class WebServer(
     async def stop_webserver_command(self, interaction: discord.Interaction):
         """Stop the webserver"""
         await interaction.response.send_message("Stopping webserver...", ephemeral=True)
-        await self.stop_webserver()
+        stopped = await self.stop_webserver()
         embed = discord.Embed(
-            title="Webserver stopped",
-            description="Webserver stopped",
-            color=discord.Color.red(),
+            title="Webserver stopped" if stopped else "Webserver not running",
+            description=(
+                "Webserver stopped" if stopped else "There was nothing to stop"
+            ),
+            color=discord.Color.red() if stopped else discord.Color.orange(),
         )
         await interaction.followup.send(embed=embed, ephemeral=True)
 
@@ -129,11 +171,15 @@ class WebServer(
         await interaction.response.send_message(
             "Restarting webserver...", ephemeral=True
         )
-        await self.restart_webserver()
+        restarted = await self.restart_webserver()
         embed = discord.Embed(
-            title="Webserver restarted",
-            description=f"Webserver restarted on port {self.PORT}",
-            color=discord.Color.green(),
+            title="Webserver restarted" if restarted else "Webserver failed to restart",
+            description=(
+                f"Webserver restarted on port {self.port}"
+                if restarted
+                else f"Could not bind port {self.port}"
+            ),
+            color=discord.Color.green() if restarted else discord.Color.red(),
         )
         await interaction.followup.send(embed=embed, ephemeral=True)
 

--- a/app/main.py
+++ b/app/main.py
@@ -385,6 +385,9 @@ class LancoBot(commands.Bot):
 
         # TODO probably a better way to inject a database into a cog
         self.database = database
+        # Cogs that failed to load, name -> error. Kept so health reporting can
+        # surface a cog that silently never came up.
+        self.failed_cogs: dict[str, str] = {}
         self.url_handlers = []
         # Message/file/image router. Cogs register an Intent (or File/Image
         # subclass) on this single list; the router owns the one on_message
@@ -437,11 +440,13 @@ class LancoBot(commands.Bot):
             else:
                 await self.load_extension(dotted)
                 result.status = CogStatus.LOADED
+            self.failed_cogs.pop(name, None)
         except Exception as e:
             logger.error(f"Failed to load cog {name}: {e}")
             capture_apm_exception(cog=name, event="cog_load")
             result.status = CogStatus.ERROR
             result.error = str(e)
+            self.failed_cogs[name] = str(e)
         return result
 
     async def load_cogs(self) -> list["CogLoadResult"]:
@@ -493,6 +498,7 @@ class LancoBot(commands.Bot):
                 logger.info(f"Unloading {name}")
                 await self.unload_extension(dotted)
                 result.status = CogStatus.UNLOADED
+                self.failed_cogs.pop(name, None)
             except Exception as e:
                 logger.error(f"Failed to unload cog {name}: {e}")
                 capture_apm_exception(cog=name, event="cog_unload")

--- a/app/utils/dist_utils.py
+++ b/app/utils/dist_utils.py
@@ -4,6 +4,7 @@ import subprocess
 import toml
 
 bot_version = None
+commit_hash = None
 
 
 def get_bot_version():
@@ -16,6 +17,11 @@ def get_bot_version():
 
 
 def get_commit_hash():
+    # Cached like the version above: the hash cannot change while the process
+    # runs, and without this every caller spawns a git subprocess.
+    global commit_hash
+    if commit_hash:
+        return commit_hash
     # Check env var first (can be injected at build time via Docker ARG/ENV)
     commit_hash = os.getenv("GIT_COMMIT_HASH")
     if commit_hash:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,16 @@ services:
     container_name: lanco-bot
     restart: unless-stopped
     env_file: .env.prod
+    environment:
+      # Compose does not read .env.prod for interpolation, only for the
+      # container's env, so a WEBSERVER_PORT set there would not reach the
+      # `ports` mapping below and the two could drift. Passing it explicitly
+      # here (which takes precedence over env_file) keeps the published port and
+      # the listening port the same value. Set it in the .env next to this file.
+      WEBSERVER_PORT: ${WEBSERVER_PORT:-8080}
+    # Embedded web server (webserver cog), serving /status
+    ports:
+      - "${WEBSERVER_PORT:-8080}:${WEBSERVER_PORT:-8080}"
     # Hard cap so a memory spike/leak restarts THIS container cleanly instead of
     # the host OOM killer reaping the process. 512m fits the bot's normal usage
     # with headroom; raise it if `docker stats` shows it sitting near the limit.


### PR DESCRIPTION
## Problem

The webserver never started: its `on_ready` had no `@commands.Cog.listener()`, so it only came up via `/web start`. `stop_webserver` cleaned up a throwaway `AppRunner` rather than the running one, so stop did nothing and restart tried to rebind a port it still held.

`/status` also made two Discord REST calls per request, so any traffic to it burned the bot's rate limit.

## Changes

- **webserver:** start from `cog_load`, stop on `cog_unload`, tracking the real runner
- **webserver:** `GET /health`, unauthenticated and minimal, 200 when connected and 503 before that
- **webserver:** `GET /status`, gated behind `WEBSERVER_TOKEN`, free of API calls, reporting `cogs_failed`
- **webserver:** `WEBSERVER_PORT`, default 8080
- **core:** track failed cog loads on the bot
- **dist_utils:** cache the commit hash, which spawned a `git rev-parse` per call

## Verified

28 checks against a stub bot whose REST methods raise, covering lifecycle, auth, and payload shape. `poetry run test`: 30 passed. Not run against a live gateway.

## Note

Set `WEBSERVER_TOKEN` in `.env.prod` or `/status` stays disabled by design.
