### PR TITLE
fix(cogs): stop cogs from breaking in direct messages

### DIFF
--- a/app/cogs/ScheduledPost/ScheduledPost.py
+++ b/app/cogs/ScheduledPost/ScheduledPost.py
@@ -85,7 +85,7 @@ class ScheduledPost(
     # --- Commands ---
 
     scheduled = app_commands.Group(
-        name="scheduledpost", description="Manage scheduled posts"
+        name="scheduledpost", description="Manage scheduled posts", guild_only=True
     )
 
     @scheduled.command(name="add", description="Schedule a new post")

--- a/app/cogs/TechLanc/TechLanc.py
+++ b/app/cogs/TechLanc/TechLanc.py
@@ -75,7 +75,7 @@ class TechLanc(
     description="Tech Lancaster updates",
 ):
     techlanc_group = app_commands.Group(
-        name="techlanc", description="Tech Lancaster commands"
+        name="techlanc", description="Tech Lancaster commands", guild_only=True
     )
 
     def __init__(self, bot):
@@ -363,6 +363,7 @@ class TechLanc(
 
     # TODO: replace with a custom command once the CustomCommands cog supports dynamic date formatting
     @commands.command(name="ps")
+    @commands.guild_only()
     @commands.cooldown(1, 30, commands.BucketType.guild)
     async def ps_command(self, ctx):
         """Post the Pub Standards meetup announcement."""
@@ -549,6 +550,7 @@ class TechLanc(
         return False
 
     @commands.command(name="tlm")
+    @commands.guild_only()
     @commands.cooldown(1, 30, commands.BucketType.guild)
     async def tlm_command(self, ctx):
         """Post the next Tech Lancaster Meetup details including speakers."""

--- a/app/cogs/TruthSocial/TruthSocial.py
+++ b/app/cogs/TruthSocial/TruthSocial.py
@@ -28,7 +28,7 @@ class TruthSocial(
     description="TruthSocial embed support",
 ):
     truth_social_group = app_commands.Group(
-        name="truthsocial", description="TruthSocial commands"
+        name="truthsocial", description="TruthSocial commands", guild_only=True
     )
 
     status_pattern = re.compile(

--- a/app/cogs/TruthSocial/TruthSocial.py
+++ b/app/cogs/TruthSocial/TruthSocial.py
@@ -58,7 +58,7 @@ class TruthSocial(
     @track_message_ids()
     @commands.Cog.listener()
     async def on_message(self, message: discord.Message) -> discord.Message | None:
-        if message.author.bot:
+        if message.author.bot or message.guild is None:
             return
 
         config = TruthSocialEmbedConfig.get_or_none(guild_id=message.guild.id)

--- a/app/cogs/adhdchannel/adhdchannel.py
+++ b/app/cogs/adhdchannel/adhdchannel.py
@@ -26,7 +26,9 @@ class ADHDChannel(
 ):
     adhd_channels = []  # TODO make this persistent
 
-    g = app_commands.Group(name="adhd", description="ADHD Channel commands")
+    g = app_commands.Group(
+        name="adhd", description="ADHD Channel commands", guild_only=True
+    )
 
     def __init__(self, bot: commands.Bot):
         super().__init__(bot)

--- a/app/cogs/admin/admin.py
+++ b/app/cogs/admin/admin.py
@@ -6,7 +6,9 @@ from utils.command_utils import is_bot_owner_or_admin
 
 
 class Admin(LancoCog, name="Admin", description="Administrative commands"):
-    g = app_commands.Group(name="admin", description="Administrative commands")
+    g = app_commands.Group(
+        name="admin", description="Administrative commands", guild_only=True
+    )
 
     def __init__(self, bot: commands.Bot):
         super().__init__(bot)

--- a/app/cogs/aiprompts/aiprompts.py
+++ b/app/cogs/aiprompts/aiprompts.py
@@ -158,10 +158,7 @@ class OpenAIPrompts(
     @commands.Cog.listener()
     @track_message_ids()
     async def on_message(self, message: discord.Message):
-        if message.author.bot:
-            return
-
-        if isinstance(message.channel, discord.DMChannel):
+        if message.author.bot or message.guild is None:
             return
 
         prefix = self.bot.get_guild_prefix(message.guild)

--- a/app/cogs/aiprompts/aiprompts.py
+++ b/app/cogs/aiprompts/aiprompts.py
@@ -68,7 +68,9 @@ class OpenAIPrompts(
 ):
     MAX_CONTEXT_QUESTIONS = 25
 
-    g = app_commands.Group(name="aiprompt", description="AI prompt commands")
+    g = app_commands.Group(
+        name="aiprompt", description="AI prompt commands", guild_only=True
+    )
 
     def __init__(self, bot: commands.Bot):
         super().__init__(bot)

--- a/app/cogs/animetoday/animetoday.py
+++ b/app/cogs/animetoday/animetoday.py
@@ -15,7 +15,7 @@ class AnimeToday(
     LancoCog, name="AnimeToday", description="Daily anime shot announcements"
 ):
     embed_group = app_commands.Group(
-        name="animetoday", description="AnimeToday commands"
+        name="animetoday", description="AnimeToday commands", guild_only=True
     )
 
     est = datetime.timezone(datetime.timedelta(hours=-5))

--- a/app/cogs/autoreact/autoreact.py
+++ b/app/cogs/autoreact/autoreact.py
@@ -93,7 +93,7 @@ class AutoReact(
 
     @commands.Cog.listener()
     async def on_message(self, message: discord.Message):
-        if message.author.bot:
+        if message.author.bot or message.guild is None:
             return
 
         config = AutoReactConfig.get_or_none(guild_id=message.guild.id)

--- a/app/cogs/autoreact/autoreact.py
+++ b/app/cogs/autoreact/autoreact.py
@@ -15,7 +15,9 @@ class AutoReact(
     name="AutoReact",
     description="Auto-react to messages with emojis based on phrases or patterns",
 ):
-    g = app_commands.Group(name="autoreact", description="AutoReact commands")
+    g = app_commands.Group(
+        name="autoreact", description="AutoReact commands", guild_only=True
+    )
 
     def __init__(self, bot: commands.Bot):
         super().__init__(bot)

--- a/app/cogs/autoresponse/autoresponse.py
+++ b/app/cogs/autoresponse/autoresponse.py
@@ -15,7 +15,9 @@ class AutoResponse(
     name="AutoResponse",
     description="Auto-reply to messages matching configured phrases or patterns",
 ):
-    g = app_commands.Group(name="autoresponse", description="AutoResponse commands")
+    g = app_commands.Group(
+        name="autoresponse", description="AutoResponse commands", guild_only=True
+    )
 
     def __init__(self, bot: commands.Bot):
         super().__init__(bot)

--- a/app/cogs/autoresponse/autoresponse.py
+++ b/app/cogs/autoresponse/autoresponse.py
@@ -89,7 +89,7 @@ class AutoResponse(
 
     @commands.Cog.listener()
     async def on_message(self, message: discord.Message):
-        if message.author.bot:
+        if message.author.bot or message.guild is None:
             return
 
         config = AutoResponseConfig.get_or_none(guild_id=message.guild.id)

--- a/app/cogs/birthday/birthday.py
+++ b/app/cogs/birthday/birthday.py
@@ -46,7 +46,9 @@ class BirthdayModal(discord.ui.Modal, title="Set your birthday"):
 
 
 class Birthday(LancoCog, name="Birthday", description="Wish a user a happy birthday"):
-    bday_group = app_commands.Group(name="bday", description="Birthday commands")
+    bday_group = app_commands.Group(
+        name="bday", description="Birthday commands", guild_only=True
+    )
 
     est = datetime.timezone(datetime.timedelta(hours=-5))
     daily_announcement_time = (datetime.time(hour=7, tzinfo=est),)

--- a/app/cogs/captcha/captcha.py
+++ b/app/cogs/captcha/captcha.py
@@ -36,7 +36,7 @@ class CaptchaCog(
     TIME_BETWEEN_ROUNDS = 3
 
     captcha_group = app_commands.Group(
-        name="captcha", description="Captcha game commands"
+        name="captcha", description="Captcha game commands", guild_only=True
     )
 
     MODES: list[CaptchaMode] = [

--- a/app/cogs/commands/commands.py
+++ b/app/cogs/commands/commands.py
@@ -177,6 +177,7 @@ class Commands(LancoCog, name="Commands", description="Custom guild commands"):
     commands_group = app_commands.Group(
         name="commands",
         description="Custom commands commands so you can command commands with commands",
+        guild_only=True,
     )
 
     def __init__(self, bot: commands.Bot):

--- a/app/cogs/commands/commands.py
+++ b/app/cogs/commands/commands.py
@@ -308,10 +308,7 @@ class Commands(LancoCog, name="Commands", description="Custom guild commands"):
     async def on_message(self, message: discord.Message) -> discord.Message:
         # TODO commands should perhaps be registered within the bot, but this works for now
 
-        if message.author.bot:
-            return None
-
-        if isinstance(message.channel, discord.DMChannel):
+        if message.author.bot or message.guild is None:
             return None
 
         prefix = self.bot.get_guild_prefix(message.guild)

--- a/app/cogs/dadjoke/dadjoke.py
+++ b/app/cogs/dadjoke/dadjoke.py
@@ -22,7 +22,9 @@ class dadjoke(
     name="dadjoke",
     description="dadjoke cog",
 ):
-    g = app_commands.Group(name="dadjoke", description="Dad joke commands")
+    g = app_commands.Group(
+        name="dadjoke", description="Dad joke commands", guild_only=True
+    )
 
     def __init__(self, bot):
         super().__init__(bot)

--- a/app/cogs/everbridge/everbridge.py
+++ b/app/cogs/everbridge/everbridge.py
@@ -27,6 +27,7 @@ class Everbridge(
     g = app_commands.Group(
         name="everbridge",
         description="Everbridge commands",
+        guild_only=True,
     )
 
     UPDATE_INTERVAL = 10  # seconds

--- a/app/cogs/facebookembed/facebookembed.py
+++ b/app/cogs/facebookembed/facebookembed.py
@@ -67,7 +67,9 @@ FB_BLUE = discord.Color.from_rgb(8, 102, 255)
 class FacebookEmbed(
     EmbedFixCog, name="Facebook Embed Fix", description="Fix Facebook embeds"
 ):
-    g = app_commands.Group(name="facebookembed", description="FacebookEmbed commands")
+    g = app_commands.Group(
+        name="facebookembed", description="FacebookEmbed commands", guild_only=True
+    )
 
     def __init__(self, bot: LancoBot):
         # The base EmbedFixCog does a single string replace of `original` with
@@ -179,7 +181,7 @@ class FacebookEmbed(
         Applies the shared guards (bot author, embed permission, angle-bracket
         and spoiler suppression, and the per-guild enabled flag).
         """
-        if message.author.bot:
+        if message.author.bot or message.guild is None:
             return None
         if not message.channel.permissions_for(message.guild.me).embed_links:
             return None

--- a/app/cogs/facts/facts.py
+++ b/app/cogs/facts/facts.py
@@ -48,7 +48,9 @@ class Facts(
     name="Facts",
     description="Community-submitted facts with random retrieval",
 ):
-    fact_group = app_commands.Group(name="fact", description="Fact commands")
+    fact_group = app_commands.Group(
+        name="fact", description="Fact commands", guild_only=True
+    )
 
     def __init__(self, bot: commands.Bot):
         super().__init__(bot)
@@ -82,6 +84,7 @@ class Facts(
         await interaction.response.send_modal(modal)
 
     @commands.command(name="fact", description="Get a random fact")
+    @commands.guild_only()
     async def fact(self, ctx: commands.Context):
         fact = self.get_random_fact(ctx.guild.id)
 

--- a/app/cogs/filefixer/filefixer.py
+++ b/app/cogs/filefixer/filefixer.py
@@ -44,7 +44,7 @@ class FileFixer(LancoCog, name="FileFixer", description="Attempt to fix files"):
 
     @commands.Cog.listener()
     async def on_message(self, message):
-        if message.author.bot:
+        if message.author.bot or message.guild is None:
             return
 
         if message.attachments:

--- a/app/cogs/filefixer/filefixer.py
+++ b/app/cogs/filefixer/filefixer.py
@@ -15,7 +15,9 @@ from .models import FileFixerConfig
 
 
 class FileFixer(LancoCog, name="FileFixer", description="Attempt to fix files"):
-    g = app_commands.Group(name="filefixer", description="FileFixer commands")
+    g = app_commands.Group(
+        name="filefixer", description="FileFixer commands", guild_only=True
+    )
 
     def __init__(self, bot: commands.Bot):
         super().__init__(bot)

--- a/app/cogs/fishbowl/fishbowl.py
+++ b/app/cogs/fishbowl/fishbowl.py
@@ -12,7 +12,9 @@ class Fishbowl(
     name="Fishbowl",
     description="Auto-delete messages in designated channels after a time delay",
 ):
-    g = app_commands.Group(name="fishbowl", description="Fishbowl commands")
+    g = app_commands.Group(
+        name="fishbowl", description="Fishbowl commands", guild_only=True
+    )
 
     def __init__(self, bot: commands.Bot):
         super().__init__(bot)

--- a/app/cogs/fixit/fixit.py
+++ b/app/cogs/fixit/fixit.py
@@ -13,7 +13,7 @@ from .models import FixItConfig
 
 
 class FixIt(LancoCog, name="FixIt", description="FixIt issue tracking"):
-    g = app_commands.Group(name="fixit", description="Fix it")
+    g = app_commands.Group(name="fixit", description="Fix it", guild_only=True)
 
     UPDATE_INTERVAL = 30  # seconds
 

--- a/app/cogs/gamestats/gamestats.py
+++ b/app/cogs/gamestats/gamestats.py
@@ -6,7 +6,7 @@ from discord.ext import commands
 
 class GameStats(LancoCog, name="GameStats", description="Game stats for the server"):
     game_stats_group = app_commands.Group(
-        name="gamestats", description="Game stat commands"
+        name="gamestats", description="Game stat commands", guild_only=True
     )
 
     def __init__(self, bot: commands.Bot):

--- a/app/cogs/geoguesser/geoguesser.py
+++ b/app/cogs/geoguesser/geoguesser.py
@@ -38,7 +38,7 @@ class GeoGuesser(
     TIME_BETWEEN_ROUNDS = 10
 
     geoguesser_group = app_commands.Group(
-        name="geoguesser", description="GeoGuesser commands"
+        name="geoguesser", description="GeoGuesser commands", guild_only=True
     )
 
     city_mode = Mode(

--- a/app/cogs/incidents/incidents.py
+++ b/app/cogs/incidents/incidents.py
@@ -36,7 +36,7 @@ class IncidentFeedOption:
 
 class Incidents(LancoCog, name="Incidents", description="LCWC Incident feed"):
     incidents_group = app_commands.Group(
-        name="incidents", description="Incident commands"
+        name="incidents", description="Incident commands", guild_only=True
     )
 
     est = pytz.timezone("US/Eastern")

--- a/app/cogs/instaembed/instaembed.py
+++ b/app/cogs/instaembed/instaembed.py
@@ -10,7 +10,9 @@ from .models import InstaEmbedConfig
 
 
 class InstaEmbed(EmbedFixCog, name="InstaEmbed", description="Instagram embed fix"):
-    g = app_commands.Group(name="instaembed", description="InstaEmbed commands")
+    g = app_commands.Group(
+        name="instaembed", description="InstaEmbed commands", guild_only=True
+    )
 
     insta_pattern = re.compile(
         r"https?://(?:www\.)?instagram\.com/(?:p|reel|reels)/[a-zA-Z0-9_-]+/?"

--- a/app/cogs/onewordstory/onewordstory.py
+++ b/app/cogs/onewordstory/onewordstory.py
@@ -32,7 +32,11 @@ class Story:
 
 
 class OneWordStory(LancoCog, name="OneWordStory", description="One Word Story game"):
-    story_group = app_commands.Group(name="story", description="One Word Story")
+    # guild_only so a story cannot be started in a DM, which the listener below
+    # ignores anyway
+    story_group = app_commands.Group(
+        name="story", description="One Word Story", guild_only=True
+    )
 
     def __init__(self, bot: commands.Bot):
         super().__init__(bot)
@@ -40,7 +44,7 @@ class OneWordStory(LancoCog, name="OneWordStory", description="One Word Story ga
 
     @commands.Cog.listener()
     async def on_message(self, message: discord.Message):
-        if message.author.bot:
+        if message.author.bot or message.guild is None:
             return
 
         story = self.get_story(message.channel.id)

--- a/app/cogs/paywallbypass/paywallbypass.py
+++ b/app/cogs/paywallbypass/paywallbypass.py
@@ -50,7 +50,9 @@ def _normalize_domain(raw: str) -> str:
 
 
 class PaywallBypass(EmbedFixCog, name="Paywall Bypass", description="Bypass paywalls"):
-    g = app_commands.Group(name="paywallbypass", description="PaywallBypass commands")
+    g = app_commands.Group(
+        name="paywallbypass", description="PaywallBypass commands", guild_only=True
+    )
 
     def __init__(self, bot: commands.Bot):
         super().__init__(bot, "Paywall Bypass", _HANDLERS, PaywallBypassConfig)

--- a/app/cogs/pdfpreview/pdfpreview.py
+++ b/app/cogs/pdfpreview/pdfpreview.py
@@ -16,7 +16,9 @@ class PDFPreview(
     name="PDFPreview",
     description="Generates a preview of a PDF file",
 ):
-    pdf_group = app_commands.Group(name="pdf", description="PDF Preview Commands")
+    pdf_group = app_commands.Group(
+        name="pdf", description="PDF Preview Commands", guild_only=True
+    )
 
     # Discord renders at most 4 images in a single multi-embed gallery, so
     # there's no point generating more page previews than that.

--- a/app/cogs/pinboard/pinboard.py
+++ b/app/cogs/pinboard/pinboard.py
@@ -10,7 +10,9 @@ from .models import PinboardPost
 class Pinboard(
     LancoCog, name="Pinboard", description="Save messages to a personal pinboard"
 ):
-    g = app_commands.Group(name="pinboard", description="Pinboard commands")
+    g = app_commands.Group(
+        name="pinboard", description="Pinboard commands", guild_only=True
+    )
 
     MAX_PINNED_MESSAGES = 30  # Maximum number of pinned messages per user, per guild
 

--- a/app/cogs/profile/profile.py
+++ b/app/cogs/profile/profile.py
@@ -68,7 +68,9 @@ class ProfileModal(discord.ui.Modal, title="Profile Details"):
 
 
 class UserProfiles(LancoCog, name="UserProfiles", description="Custom user profiles"):
-    profiles_group = app_commands.Group(name="profile", description="User profiles")
+    profiles_group = app_commands.Group(
+        name="profile", description="User profiles", guild_only=True
+    )
 
     def __init__(self, bot: commands.Bot):
         super().__init__(bot)

--- a/app/cogs/r9k/r9k.py
+++ b/app/cogs/r9k/r9k.py
@@ -33,7 +33,9 @@ class R9K(
     name="R9K",
     description="R9K channel: every message must be unique, duplicates are removed",
 ):
-    r9k_group = app_commands.Group(name="r9k", description="R9K channel commands")
+    r9k_group = app_commands.Group(
+        name="r9k", description="R9K channel commands", guild_only=True
+    )
 
     def __init__(self, bot):
         super().__init__(bot)

--- a/app/cogs/reacttrack/reacttrack.py
+++ b/app/cogs/reacttrack/reacttrack.py
@@ -12,7 +12,9 @@ class ReactTrack(
     name="ReactTrack",
     description="Track reactions",
 ):
-    g = app_commands.Group(name="reacttrack", description="ReactTrack commands")
+    g = app_commands.Group(
+        name="reacttrack", description="ReactTrack commands", guild_only=True
+    )
 
     def __init__(self, bot: commands.Bot):
         super().__init__(bot)

--- a/app/cogs/redditembed/redditembed.py
+++ b/app/cogs/redditembed/redditembed.py
@@ -12,7 +12,9 @@ from .models import RedditEmbedConfig
 class RedditEmbed(
     EmbedFixCog, name="RedditEmbed", description="Fix Reddit embed previews in Discord"
 ):
-    g = app_commands.Group(name="redditembed", description="RedditEmbed commands")
+    g = app_commands.Group(
+        name="redditembed", description="RedditEmbed commands", guild_only=True
+    )
 
     reddit_pattern = re.compile(r"https?://(?:www\.)?reddit\.com/\S+")
 

--- a/app/cogs/redditfeed/redditfeed.py
+++ b/app/cogs/redditfeed/redditfeed.py
@@ -19,7 +19,7 @@ from .models import RedditFeedConfig, RedditPost
 
 class RedditFeed(LancoCog, name="RedditFeed", description="Reddit feed polling"):
     reddit_feed_group = app_commands.Group(
-        name="reddit", description="Poll Reddit for new posts"
+        name="reddit", description="Poll Reddit for new posts", guild_only=True
     )
 
     UPDATE_INTERVAL = 10  # seconds

--- a/app/cogs/remindme/remindme.py
+++ b/app/cogs/remindme/remindme.py
@@ -64,6 +64,7 @@ class RemindMe(
         name="remindme",
         description="Reminds you of something after a specified duration",
     )
+    @commands.guild_only()
     async def remindme(self, ctx: commands.Context, duration: str, *, reminder: str):
         """Reminds you of something after a specified duration. Example: !remindme 2h take out the trash"""
 

--- a/app/cogs/rolestats/rolestats.py
+++ b/app/cogs/rolestats/rolestats.py
@@ -16,7 +16,9 @@ class RoleStats(
     name="RoleStats",
     description="Show member counts and stats per role",
 ):
-    g = app_commands.Group(name="rolestats", description="RoleStats commands")
+    g = app_commands.Group(
+        name="rolestats", description="RoleStats commands", guild_only=True
+    )
 
     def __init__(self, bot: commands.Bot):
         super().__init__(bot)

--- a/app/cogs/rssfeed/rssfeed.py
+++ b/app/cogs/rssfeed/rssfeed.py
@@ -20,7 +20,9 @@ class RssFeed(
     description="Poll RSS feeds and post new entries to configured channels",
 ):
     UPDATE_INTERVAL = 10  # seconds
-    g = app_commands.Group(name="rssfeed", description="RSSFeed commands")
+    g = app_commands.Group(
+        name="rssfeed", description="RSSFeed commands", guild_only=True
+    )
 
     def __init__(self, bot: commands.Bot):
         super().__init__(bot)

--- a/app/cogs/spotifyembed/spotifyembed.py
+++ b/app/cogs/spotifyembed/spotifyembed.py
@@ -47,7 +47,7 @@ class SpotifyEmbed(
 
     @commands.Cog.listener()
     async def on_message(self, message):
-        if message.author.bot:
+        if message.author.bot or message.guild is None:
             return
 
         match = self.spotify_url_pattern.search(message.content)

--- a/app/cogs/spotifyembed/spotifyembed.py
+++ b/app/cogs/spotifyembed/spotifyembed.py
@@ -17,7 +17,7 @@ class SpotifyEmbed(
     LancoCog, name="Spotify Embed Fix", description="Fix Spotify embeds"
 ):
     embed_group = app_commands.Group(
-        name="spotifyembed", description="SpotifyEmbed commands"
+        name="spotifyembed", description="SpotifyEmbed commands", guild_only=True
     )
 
     spotify_url_pattern = re.compile(

--- a/app/cogs/summarize/summarize.py
+++ b/app/cogs/summarize/summarize.py
@@ -99,6 +99,7 @@ class Summarize(
     @commands.command(
         name="topic", description="Will say what the current channel is talking about"
     )
+    @commands.guild_only()
     @command_channel_lock()
     @track_message_ids()
     async def topic(self, ctx: commands.Context):

--- a/app/cogs/tiktokembed/tiktokembed.py
+++ b/app/cogs/tiktokembed/tiktokembed.py
@@ -12,7 +12,9 @@ from .models import TikTokEmbedConfig
 class TikTokEmbed(
     EmbedFixCog, name="TikTok Embed Fix", description="Fix TikTok embeds"
 ):
-    g = app_commands.Group(name="tiktokembed", description="TikTokEmbed commands")
+    g = app_commands.Group(
+        name="tiktokembed", description="TikTokEmbed commands", guild_only=True
+    )
 
     tiktok_pattern = re.compile(
         r"https?://(?:www\.)?tiktok\.com/(?!shop(?:/|$)|product(?:/|$))\S+"

--- a/app/cogs/transcribe/transcribe.py
+++ b/app/cogs/transcribe/transcribe.py
@@ -17,7 +17,9 @@ class Transcribe(
     name="Transcribe",
     description="Transcription commands for audio files and voice messages",
 ):
-    g = app_commands.Group(name="transcribe", description="Transcribe commands")
+    g = app_commands.Group(
+        name="transcribe", description="Transcribe commands", guild_only=True
+    )
 
     def __init__(self, bot: commands.Bot):
         super().__init__(bot)

--- a/app/cogs/twitterembed/twitterembed.py
+++ b/app/cogs/twitterembed/twitterembed.py
@@ -12,7 +12,9 @@ from .models import TwitterEmbedConfig
 class TwitterEmbed(
     EmbedFixCog, name="Twitter/X Embed Fix", description="Fix Twitter/X embeds"
 ):
-    g = app_commands.Group(name="twitterembed", description="TwitterEmbed commands")
+    g = app_commands.Group(
+        name="twitterembed", description="TwitterEmbed commands", guild_only=True
+    )
 
     def __init__(self, bot: LancoBot):
         twitter_pattern = re.compile(

--- a/app/cogs/verification/verification.py
+++ b/app/cogs/verification/verification.py
@@ -20,7 +20,9 @@ class Verification(
     name="Verification",
     description="Community-voted new member verification system",
 ):
-    g = app_commands.Group(name="verification", description="Verification commands")
+    g = app_commands.Group(
+        name="verification", description="Verification commands", guild_only=True
+    )
 
     APPROVAL_EMOJI = "✅"
     DENIAL_EMOJI = "❌"

--- a/app/cogs/webpreview/webpreview.py
+++ b/app/cogs/webpreview/webpreview.py
@@ -23,7 +23,9 @@ class WebPreview(
     name="WebPreview",
     description="Generate rich previews for URLs posted in messages",
 ):
-    g = app_commands.Group(name="webpreview", description="Web preview commands")
+    g = app_commands.Group(
+        name="webpreview", description="Web preview commands", guild_only=True
+    )
 
     def __init__(self, bot: commands.Bot):
         super().__init__(bot)

--- a/app/cogs/webpreview/webpreview.py
+++ b/app/cogs/webpreview/webpreview.py
@@ -34,7 +34,7 @@ class WebPreview(
 
     @commands.Cog.listener()
     async def on_message(self, message: discord.Message):
-        if message.author.bot:
+        if message.author.bot or message.guild is None:
             return
         if message.content.startswith(self.bot.get_guild_prefix(message.guild)):
             return

--- a/app/cogs/youtube/youtube.py
+++ b/app/cogs/youtube/youtube.py
@@ -26,7 +26,9 @@ class Youtube(
     name="Youtube",
     description="Subscribe to YouTube channels and post new video notifications",
 ):
-    g = app_commands.Group(name="youtube", description="Youtube commands")
+    g = app_commands.Group(
+        name="youtube", description="Youtube commands", guild_only=True
+    )
 
     UPDATE_INTERVAL = 10 * 60  # 10 minutes
 

--- a/app/utils/command_utils.py
+++ b/app/utils/command_utils.py
@@ -16,6 +16,13 @@ def is_bot_owner():
 
 def is_bot_owner_or_admin():
     def predicate(interaction: discord.Interaction):
+        # Guild admin is meaningless outside a guild, and in a DM `guild` is
+        # None while `user` is a User with no guild_permissions, so both checks
+        # below would raise. Returning False makes this an ordinary
+        # CheckFailure, which the error handlers already ignore. The owner is
+        # refused too: every command using this check acts on a guild.
+        if interaction.guild is None:
+            return False
         if is_bot_owner_or_team_member(interaction):
             return True
         if interaction.guild.owner_id == interaction.user.id:

--- a/tests/test_dm_safety.py
+++ b/tests/test_dm_safety.py
@@ -106,21 +106,25 @@ async def test_no_listener_raises_on_a_dm(bot):
     raised = {}
     exercised = 0
     for cog in bot.cogs.values():
-        fn = getattr(type(cog), "on_message", None)
-        if fn is None or not isinstance(fn, types.FunctionType):
-            continue
-        exercised += 1
-        for make in PAYLOADS:
-            try:
-                await fn(cog, make())
-            except AttributeError as e:
-                # The failure this test exists for: touching a None guild
-                if "guild" in str(e) or "NoneType" in str(e):
-                    raised.setdefault(cog.qualified_name, str(e))
-            except Exception:
-                # Anything else is the stub message being incomplete, not a
-                # DM-handling bug
-                pass
+        # get_listeners() rather than looking up an `on_message` attribute:
+        # listeners can be registered under any function name via
+        # @commands.Cog.listener("on_message"), and facebookembed has three.
+        for event_name, listener in cog.get_listeners():
+            if event_name != "on_message":
+                continue
+            exercised += 1
+            label = f"{cog.qualified_name}.{listener.__name__}"
+            for make in PAYLOADS:
+                try:
+                    await listener(make())
+                except AttributeError as e:
+                    # The failure this test exists for: touching a None guild
+                    if "guild" in str(e) or "NoneType" in str(e):
+                        raised.setdefault(label, str(e))
+                except Exception:
+                    # Anything else is the stub message being incomplete, not a
+                    # DM-handling bug
+                    pass
 
     assert exercised, "no on_message listeners were exercised"
     assert not raised, f"listeners raising on a DM: {raised}"

--- a/tests/test_dm_safety.py
+++ b/tests/test_dm_safety.py
@@ -1,0 +1,178 @@
+"""Cog on_message listeners must survive a direct message.
+
+`message.guild` is None in a DM and in a group DM. A listener that dereferences
+it without checking raises AttributeError on every DM, which surfaces as an
+unhandled error in on_error and a report to APM.
+
+Two complementary checks:
+
+- a runtime one, dispatching a DM-shaped message at every listener that loads
+- a static one, covering the cogs that cannot be imported without their optional
+  system libraries (filefixer needs cairo, transcribe needs whisper)
+"""
+
+import ast
+import os
+import re
+import types
+
+import discord
+import pytest
+
+from tests.test_bot import bot, test_db  # noqa: F401  (fixtures)
+
+COGS_DIR = os.path.join(os.path.dirname(__file__), "..", "app", "cogs")
+
+pytestmark = pytest.mark.asyncio
+
+# Any of these in a listener body counts as guarding the DM case. The trailing
+# lookahead on the bare form keeps `if message.guild.id == x` from being read as
+# a guard, while still matching the ternary form `x if message.guild else y`.
+GUARD_FORMS = (
+    r"message\.guild\s+is\s+None",
+    r"message\.guild\s+is\s+not\s+None",
+    r"not\s+message\.guild(?![.\w])",
+    r"if\s+message\.guild(?![.\w])",
+)
+
+
+class _Author:
+    bot = False
+    id = 999
+    display_name = "someone"
+
+    def __str__(self):
+        return "someone"
+
+
+class _Attachment:
+    filename = "x.heic"
+    url = "http://example.invalid/x.heic"
+    content_type = "image/heic"
+    size = 10
+
+
+class _DMChannel(discord.DMChannel):
+    def __init__(self):
+        self.id = 4242
+
+    async def send(self, *a, **k):
+        return None
+
+    async def fetch_message(self, *a, **k):
+        return None
+
+    async def typing(self):
+        return None
+
+
+class _DM:
+    """A message shaped like a DM: guild is None."""
+
+    def __init__(self, content="", attachments=()):
+        self.author = _Author()
+        self.guild = None
+        self.channel = _DMChannel()
+        self.content = content
+        self.attachments = list(attachments)
+        self.id = 1
+        self.embeds = []
+
+    async def add_reaction(self, *a, **k):
+        return None
+
+    async def reply(self, *a, **k):
+        return None
+
+    async def delete(self, *a, **k):
+        return None
+
+
+# Content shaped to reach the deeper branches of the URL and attachment cogs
+PAYLOADS = (
+    lambda: _DM("hello there"),
+    lambda: _DM("look http://example.invalid/page"),
+    lambda: _DM("https://open.spotify.com/track/abc123"),
+    lambda: _DM("https://truthsocial.com/@someone/posts/123456"),
+    lambda: _DM("file", [_Attachment()]),
+)
+
+
+async def test_no_listener_raises_on_a_dm(bot):
+    for entry in os.scandir(COGS_DIR):
+        if entry.is_dir() and os.path.isfile(os.path.join(entry.path, "__init__.py")):
+            await bot.load_cog(entry.name)
+
+    raised = {}
+    exercised = 0
+    for cog in bot.cogs.values():
+        fn = getattr(type(cog), "on_message", None)
+        if fn is None or not isinstance(fn, types.FunctionType):
+            continue
+        exercised += 1
+        for make in PAYLOADS:
+            try:
+                await fn(cog, make())
+            except AttributeError as e:
+                # The failure this test exists for: touching a None guild
+                if "guild" in str(e) or "NoneType" in str(e):
+                    raised.setdefault(cog.qualified_name, str(e))
+            except Exception:
+                # Anything else is the stub message being incomplete, not a
+                # DM-handling bug
+                pass
+
+    assert exercised, "no on_message listeners were exercised"
+    assert not raised, f"listeners raising on a DM: {raised}"
+
+
+def _dereferences_guild(func: ast.AST) -> bool:
+    """True if the body reads an attribute off message.guild.
+
+    Passing `message.guild` along as a value is fine, since the callee can take
+    None. `message.guild.id` is what raises in a DM.
+    """
+    for node in ast.walk(func):
+        if not isinstance(node, ast.Attribute):
+            continue
+        inner = node.value
+        if (
+            isinstance(inner, ast.Attribute)
+            and inner.attr == "guild"
+            and isinstance(inner.value, ast.Name)
+            and inner.value.id == "message"
+        ):
+            return True
+    return False
+
+
+def test_guild_referencing_listeners_guard_against_dms():
+    """Static counterpart, so cogs that cannot import here are still covered."""
+    offenders = []
+    for root, _dirs, files in os.walk(COGS_DIR):
+        if "__pycache__" in root:
+            continue
+        for fn in files:
+            if not fn.endswith(".py"):
+                continue
+            path = os.path.join(root, fn)
+            src = open(path, encoding="utf-8", errors="replace").read()
+            if "async def on_message" not in src:
+                continue
+            lines = src.split("\n")
+            for node in ast.walk(ast.parse(src)):
+                if not (
+                    isinstance(node, ast.AsyncFunctionDef) and node.name == "on_message"
+                ):
+                    continue
+                if not _dereferences_guild(node):
+                    continue
+                body = "\n".join(lines[node.lineno - 1 : node.end_lineno])
+                if not any(re.search(form, body) for form in GUARD_FORMS):
+                    rel = os.path.relpath(path, COGS_DIR).replace(os.sep, "/")
+                    offenders.append(f"{rel}:{node.lineno}")
+
+    assert not offenders, (
+        "on_message listeners referencing message.guild without a DM guard: "
+        + ", ".join(offenders)
+    )


### PR DESCRIPTION
## Problem

`message.guild` is None in a DM, and nothing accounted for it. Several `on_message` listeners dereferenced it directly, so any direct message raised unhandled `AttributeError`s.

`is_bot_owner_or_admin()` also crashed on `interaction.guild.owner_id` before the command body ran, affecting all 88 commands using it. And every guild-scoped group was still offered in DMs, where it can only fail.

## Changes

- **cogs:** guard the `on_message` listeners that dereference `message.guild`. Listeners run before checks, so `guild_only` cannot help here
- **facebookembed:** guard the helper shared by its three listeners
- **command_utils:** `is_bot_owner_or_admin()` returns False outside a guild instead of raising, so it becomes an ordinary CheckFailure
- **cogs:** `guild_only=True` on 41 guild-scoped groups, leaving the handful that work fine in DMs alone
- **cogs:** `@commands.guild_only()` on the prefix commands that use `ctx.guild`
- **tests:** dispatch a DM at every registered `on_message` listener, plus a static check for cogs that cannot import without optional system libraries

## Verified

Reproduced live against the dev bot, then confirmed the same inputs are handled cleanly after the fix. `poetry run test`: 32 passed. Removing any guard fails the new test with the offending listener named.

## Note

Needs a `/sync`, since `guild_only` lives in the command payload Discord holds.
