### PR TITLE
fix(compose): move the filebeat sidecar out of the deploy path

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -76,9 +76,9 @@ LOGTAIL_TOKEN=
 # Set this to logs/lancobot.ecs.json when running the filebeat sidecar.
 ECS_LOG_FILE=
 
-# Elasticsearch, for the filebeat logging sidecar only (see docker-compose.yml,
-# `docker-compose --profile logging up -d`). Separate from the APM credentials
-# above: APM Server and Elasticsearch are different endpoints.
+# Elasticsearch, for the filebeat logging sidecar only (see
+# docker-compose.logging.yml). Separate from the APM credentials above: APM
+# Server and Elasticsearch are different endpoints.
 ELASTICSEARCH_HOST=
 # API key in Filebeat's "id:api_key" form, from Kibana > Stack Management >
 # API keys. Needs write access to the logs-* data streams.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -88,6 +88,11 @@ jobs:
           script_stop: true
           command_timeout: 5m
           script: |
+            # -e because script_stop alone did not abort this script: a
+            # docker-compose config error let `down` and `up` both fail, left
+            # the previous container running, and the check below then passed
+            # on it, so a deploy that deployed nothing reported success.
+            set -e
             set +x
             cd ~/lanco-discord-bot
             # Pinned, not inherited: compose reads BOT_ENV/CONTAINER_NAME from
@@ -96,14 +101,22 @@ jobs:
             # cannot redirect an automated production deploy.
             export BOT_ENV=prod
             export CONTAINER_NAME=lanco-bot
+            IMAGE=ghcr.io/$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]'):latest
             git pull origin master
-            docker pull ghcr.io/$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]'):latest
+            docker pull "$IMAGE"
             docker-compose -p lanco-discord-bot down
             docker-compose -p lanco-discord-bot up -d
             docker image prune -f
             sleep 5
-            if [ -z "$(docker ps -q --filter name=^lanco-bot$ --filter status=running)" ]; then
-              echo "lanco-bot container is not running after deploy"
+            # Compare the running image to the one just pulled. Checking only
+            # that a container named lanco-bot is up passes when the deploy did
+            # nothing at all and the previous container is simply still there.
+            WANT=$(docker image inspect --format '{{.Id}}' "$IMAGE")
+            GOT=$(docker inspect --format '{{.Image}}' lanco-bot 2>/dev/null || echo none)
+            if [ "$WANT" != "$GOT" ]; then
+              echo "lanco-bot is not running the image that was just deployed"
+              echo "  expected $WANT"
+              echo "  running  $GOT"
               docker logs --tail 50 lanco-bot || true
               exit 1
             fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,13 +145,13 @@ Instrumentation is central, so a new cog is covered the day it lands. Work with 
 
 Each document carries `service.name`, `service.version`, `service.environment`, `event.dataset`, and the `data_stream.*` trio, plus `trace.id` and `transaction.id` whenever a transaction was in flight. That last pair is the point: it lets Kibana jump from a log line to the command that produced it, and puts the surrounding lines on the APM service's Logs tab. `app/utils/logs.py` documents why those fields are merged the way they are; getting it wrong drops log lines silently.
 
-Shipping is a Filebeat sidecar in `docker-compose.yml`, behind a `logging` profile so it never starts for anyone who has not configured Elasticsearch:
+Shipping is a Filebeat sidecar in `docker-compose.logging.yml`, a separate override file so it never starts for anyone who has not configured Elasticsearch:
 
 ```bash
-docker-compose --profile logging up -d
+docker-compose -f docker-compose.yml -f docker-compose.logging.yml up -d
 ```
 
-It needs `ECS_LOG_FILE` set so there is something to tail, plus `ELASTICSEARCH_HOST` and `ELASTICSEARCH_API_KEY` in the same `.env.<env>` file. Those are Elasticsearch credentials, not the APM ones: different endpoint, different key, and the key is Filebeat's unencoded `id:key` form rather than Kibana's base64 blob. The automated deploy passes no profile, so to keep the sidecar running there put `COMPOSE_PROFILES=logging` in the `.env` beside `docker-compose.yml`; compose reads that itself and the workflow needs no change.
+It needs `ECS_LOG_FILE` set so there is something to tail, plus `ELASTICSEARCH_HOST` and `ELASTICSEARCH_API_KEY` in the same `.env.<env>` file. Those are Elasticsearch credentials, not the APM ones: different endpoint, different key, and the key is Filebeat's unencoded `id:key` form rather than Kibana's base64 blob. To keep the sidecar running through the automated deploy, put `COMPOSE_FILE=docker-compose.yml:docker-compose.logging.yml` in the `.env` beside `docker-compose.yml`; compose reads that itself and the workflow needs no change. An override file rather than a `profiles:` entry because `profiles` requires docker-compose 1.28+ and is a hard config error on anything older, which would break the deploy.
 
 Filebeat parses nothing and routes purely on the `data_stream.*` fields, so the log shape is decided in one place and dev logs cannot reach the prod data stream: `logs-lanco_bot.log-dev` and `logs-lanco_bot.log-prod`. Tailing a file rather than posting from inside the bot means logs written just before a crash still get shipped.
 

--- a/docker-compose.logging.yml
+++ b/docker-compose.logging.yml
@@ -1,0 +1,41 @@
+# Filebeat sidecar, shipping the bot's ECS log file into Elasticsearch.
+#
+# A separate file rather than a `profiles:` entry in docker-compose.yml, which
+# needs docker-compose 1.28+ and is a config error on anything older. Overrides
+# work on every version, and keep the deploy path free of anything the host's
+# compose might reject.
+#
+# Enable per command:
+#
+#   docker-compose -f docker-compose.yml -f docker-compose.logging.yml up -d
+#
+# Or permanently, including for the automated deploy, by putting this in the
+# .env beside docker-compose.yml, which compose reads by itself:
+#
+#   COMPOSE_FILE=docker-compose.yml:docker-compose.logging.yml
+#
+# Needs ECS_LOG_FILE, ELASTICSEARCH_HOST and ELASTICSEARCH_API_KEY in the
+# .env.<env> file. Out-of-process on purpose: tailing a file means logs the bot
+# wrote before it died still get shipped, which is when they are worth having.
+version: "2.4"
+
+services:
+  filebeat:
+    image: docker.elastic.co/beats/filebeat:${FILEBEAT_VERSION:-9.4.4}
+    container_name: ${CONTAINER_NAME:-lanco-bot}-filebeat
+    restart: unless-stopped
+    env_file: .env.${BOT_ENV:-prod}
+    # root so it can write its read-offset registry to the named volume below,
+    # and --strict.perms=false because a bind-mounted config keeps the host's
+    # ownership, which Filebeat's default permission check rejects.
+    user: root
+    command: ["--strict.perms=false"]
+    volumes:
+      - ./filebeat.yml:/usr/share/filebeat/filebeat.yml:ro
+      - ./logs:/logs:ro
+      # Survives restarts so a redeploy does not re-ship the whole file.
+      - filebeat-data:/usr/share/filebeat/data
+    mem_limit: 256m
+
+volumes:
+  filebeat-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ version: "2.4"
 #
 # which loads .env.dev and reports itself as dev to Elastic APM. Run it from
 # its own directory so the ./data volume below is a separate database.
+#
+# Log shipping lives in docker-compose.logging.yml; see that file to enable it.
 services:
   app:
     image: ghcr.io/nateshoffner/lanco-discord-bot:latest
@@ -43,35 +45,3 @@ services:
       - ./data:/app/data
       - ./logs:/app/logs
 
-  # Ships the bot's ECS log file into Elasticsearch. Opt-in, because it is
-  # useless without ELASTICSEARCH_HOST and ELASTICSEARCH_API_KEY and would
-  # otherwise restart-loop for anyone who has not set them:
-  #
-  #   docker-compose --profile logging up -d
-  #
-  # The automated deploy passes no profile, so to keep it running there put
-  # COMPOSE_PROFILES=logging in the .env beside this file; compose reads that
-  # on its own and no workflow change is needed.
-  #
-  # Out-of-process on purpose. Tailing a file means logs the bot wrote before
-  # it died still get shipped, which is exactly when they are worth having.
-  filebeat:
-    profiles: ["logging"]
-    image: docker.elastic.co/beats/filebeat:${FILEBEAT_VERSION:-9.4.4}
-    container_name: ${CONTAINER_NAME:-lanco-bot}-filebeat
-    restart: unless-stopped
-    env_file: .env.${BOT_ENV:-prod}
-    # root so it can write its read-offset registry to the named volume below,
-    # and --strict.perms=false because a bind-mounted config keeps the host's
-    # ownership, which Filebeat's default permission check rejects.
-    user: root
-    command: ["--strict.perms=false"]
-    volumes:
-      - ./filebeat.yml:/usr/share/filebeat/filebeat.yml:ro
-      - ./logs:/logs:ro
-      # Survives restarts so a redeploy does not re-ship the whole file.
-      - filebeat-data:/usr/share/filebeat/data
-    mem_limit: 256m
-
-volumes:
-  filebeat-data:

--- a/filebeat.yml
+++ b/filebeat.yml
@@ -4,7 +4,7 @@
 # adds nothing but host metadata. Reformatting here would be a second place the
 # log shape is decided, and the two would drift.
 #
-# Enable with:  docker-compose --profile logging up -d
+# Enable with:  docker-compose -f docker-compose.yml -f docker-compose.logging.yml up -d
 
 filebeat.inputs:
   - type: filestream


### PR DESCRIPTION
## Problem

`profiles:` on the filebeat service needs docker-compose 1.28+. The VPS runs an older one, so it is a hard config error:

```
Unsupported config option for services.filebeat: 'profiles'
```

Both `docker-compose down` and `up -d` failed on it during the #183 deploy. The previous container was therefore never stopped, the new image never started, and the health check, which only asks whether a container named `lanco-bot` is running, passed on the container that was already there. The deploy reported success having deployed nothing.

## Changes

- **compose:** filebeat moves to `docker-compose.logging.yml`, an override file, which every compose version understands. `docker-compose.yml` is back to one service and nothing version-dependent. Enable with `-f docker-compose.yml -f docker-compose.logging.yml`, or `COMPOSE_FILE` in the adjacent `.env` for the automated deploy.
- **deploy:** `set -e`, because `script_stop` did not abort the script on those failures.
- **deploy:** the health check compares the running container's image to the one just pulled, instead of only checking that something with the right name is up.

## Verified

`docker compose config` resolves `app` alone from the main file, `app` + `filebeat` with the override, and the same via `COMPOSE_FILE`. No `profiles` key remains in the deploy path. `filebeat test config` passes on 9.4.4, deploy script passes `bash -n`, 66 tests pass.

The new health check fails closed against exactly this bug: with compose erroring, the running image would not match the pulled one.