### PR TITLE
chore(deploy): drop the script_stop input the action never accepted

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -85,13 +85,14 @@ jobs:
           host: ${{ secrets.VPS_HOST }}
           username: root
           key: ${{ secrets.VPS_SSH_KEY }}
-          script_stop: true
           command_timeout: 5m
           script: |
-            # -e because script_stop alone did not abort this script: a
-            # docker-compose config error let `down` and `up` both fail, left
-            # the previous container running, and the check below then passed
-            # on it, so a deploy that deployed nothing reported success.
+            # -e is what actually aborts this script. `script_stop: true` was
+            # set here for years but is not an input this action accepts, so it
+            # was ignored: a docker-compose config error let `down` and `up`
+            # both fail, left the previous container running, and the check
+            # below passed on it. The deploy reported success having deployed
+            # nothing.
             set -e
             set +x
             cd ~/lanco-discord-bot


### PR DESCRIPTION
## Problem

`appleboy/ssh-action@v1` does not accept `script_stop`, and says so on every run:

```
##[warning]Unexpected input(s) 'script_stop', valid inputs are ['host', 'port', ...]
```

It has therefore been doing nothing, which is why a deploy whose `docker-compose` calls both failed still reported success. #184 added `set -e`, which is what actually aborts the script. Leaving the dead input in place implies a safety net that is not there.

## Changes

- **deploy:** remove `script_stop`, and correct the comment above `set -e` to say why it is load-bearing.

## Verified

Workflow YAML parses. No behaviour change: the input was already ignored.