### PR TITLE
fix(logs): send filebeat's own logs to stderr so failures are visible

### DIFF
--- a/filebeat.yml
+++ b/filebeat.yml
@@ -39,5 +39,10 @@ output.elasticsearch:
 setup.template.enabled: false
 setup.ilm.enabled: false
 
+# To stderr, so `docker logs` shows them. to_files:false alone sends them
+# nowhere unless the process was started with -e, which the compose service
+# does not pass: a shipper that cannot report its own failures looks
+# identical to one that is working.
 logging.level: info
 logging.to_files: false
+logging.to_stderr: true


### PR DESCRIPTION
## Problem

`filebeat.yml` sets `logging.to_files: false` and never sets `logging.to_stderr`, so Filebeat's own logs go nowhere unless the process is started with `-e`. The compose service does not pass it.

Result: a Filebeat container reporting `Up 5 minutes` with `docker logs` completely empty, whether it is shipping fine or failing on every batch. It was only visible in ad-hoc testing because those runs used `-e`, which masked the gap in the config itself.

A shipper that cannot report its own failures is indistinguishable from one that is working.

## Changes

- **logs:** `logging.to_stderr: true` in `filebeat.yml`, so diagnostics reach `docker logs` regardless of how the process was launched.

## Verified

Ran the image against this config without `-e`: startup lines now appear on stderr, where previously there was no output at all. `filebeat test config` still passes on 9.4.4.