### PR TITLE
fix(deploy): trigger on filebeat and compose override changes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,9 @@ on:
       - "pyproject.toml"
       - "poetry.lock"
       - "Dockerfile"
-      - "docker-compose.yml"
+      # Glob, so a new compose override is covered the day it is added.
+      - "docker-compose*.yml"
+      - "filebeat.yml"
       - ".github/workflows/deploy.yml"
 
 env:


### PR DESCRIPTION
## Problem

The deploy's `paths:` filter lists `docker-compose.yml` but not `filebeat.yml` or `docker-compose.logging.yml`, both of which reach the VPS via the `git pull` inside the deploy and both of which need a container recreate to take effect.

So #187, which changed only `filebeat.yml`, merged without deploying anything. #184 deployed only because it happened to also touch `docker-compose.yml`. The gap arrived with #183 and #184, which added deployment-relevant files outside the filter.

## Changes

- **deploy:** `docker-compose.yml` becomes `docker-compose*.yml` so overrides are covered as they are added, and `filebeat.yml` is listed.

## Verified

Workflow YAML parses. Merging this modifies `.github/workflows/deploy.yml`, which is already in the filter, so it triggers a deploy itself and that `git pull` carries the merged #187 to the VPS.