### PR TITLE
ci(test): run the test suite on pull requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,54 @@
+name: Test
+
+# Tests only ever ran on push to master, as the first job of the deploy
+# pipeline, so a bad change was already on master by the time it failed.
+# This runs the same suite on the pull request instead.
+on:
+  pull_request:
+    # Deliberately the code-relevant subset of deploy.yml's path list.
+    # poetry.lock matters most: when a bump satisfies the existing version
+    # constraint, dependabot rewrites the lock and nothing else, which matched
+    # no trigger here and arrived on master unchecked. docker-compose*.yml and
+    # filebeat.yml are in deploy.yml but omitted here because neither can
+    # affect the test suite. Anything added there that runs code belongs here.
+    paths:
+      - "app/**"
+      - "tests/**"
+      - "migrations/**"
+      - "tools/**"
+      - "pyproject.toml"
+      - "poetry.lock"
+      - "Dockerfile"
+      - ".github/workflows/test.yml"
+
+# A new push to the same PR makes the in-flight run irrelevant.
+concurrency:
+  group: test-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      # Kept in step with deploy.yml's test job. If that one changes its
+      # python version or how it invokes the suite, change it here too, or the
+      # pull request stops predicting what the merge will do.
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.10"
+
+      - name: Install Poetry
+        run: pip install poetry
+
+      - name: Install dependencies
+        run: poetry install
+
+      # BOT_ENV=test, set by this entrypoint, loads .env.test only and never
+      # .env, so this needs no secrets.
+      - name: Run tests
+        run: poetry run test


### PR DESCRIPTION
Tests only ran on push to `master`, as the first job of the deploy pipeline, so a failing change was already on master by the time anything caught it. The only pull request check was black lint, which is a formatting check gated on `app/**` and `pyproject.toml`.

That left a specific hole: when a dependency bump satisfies the existing version constraint, dependabot rewrites `poetry.lock` and nothing else. `poetry.lock` is in deploy's path filter but not lint's, so those pull requests matched no trigger and showed no checks at all. #176 and #177 are both in that state right now, and both change libraries that run in production code paths (`croniter` drives ScheduledPost's scheduling, `dateparser` parses user input in remindme and ScheduledPost).

This adds a `pull_request` workflow running the same suite the deploy job runs.

- Paths are the code-relevant subset of deploy's list, including `poetry.lock`. `docker-compose*.yml` and `filebeat.yml` are omitted because neither can affect the test suite.
- The steps mirror deploy's test job exactly so the two cannot drift into disagreeing about what "tests pass" means.
- `concurrency` cancels a superseded run when a pull request is pushed to again.
- No secrets needed: `poetry run test` sets `BOT_ENV=test`, which loads `.env.test` only and never `.env`.

Deploy keeps its own test job, which stays the gate before an image is built and pushed. This just moves the same signal earlier.

The workflow's own path is in the filter, so this pull request exercises it.

Worth making this a required status check on `master` afterward, otherwise it reports but does not block.