### PR TITLE
chore(deps-dev): bump isort from 5.13.2 to 8.0.1

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1977,18 +1977,18 @@ files = [
 
 [[package]]
 name = "isort"
-version = "5.13.2"
+version = "8.0.1"
 description = "A Python utility / library to sort Python imports."
 optional = false
-python-versions = ">=3.8.0"
+python-versions = ">=3.10.0"
 groups = ["dev"]
 files = [
-    {file = "isort-5.13.2-py3-none-any.whl", hash = "sha256:8ca5e72a8d85860d5a3fa69b8745237f2939afe12dbf656afbcb47fe72d947a6"},
-    {file = "isort-5.13.2.tar.gz", hash = "sha256:48fdfcb9face5d58a4f6dde2e72a1fb8dcaf8ab26f95ab49fab84c2ddefb0109"},
+    {file = "isort-8.0.1-py3-none-any.whl", hash = "sha256:28b89bc70f751b559aeca209e6120393d43fbe2490de0559662be7a9787e3d75"},
+    {file = "isort-8.0.1.tar.gz", hash = "sha256:171ac4ff559cdc060bcfff550bc8404a486fee0caab245679c2abe7cb253c78d"},
 ]
 
 [package.extras]
-colors = ["colorama (>=0.4.6)"]
+colors = ["colorama"]
 
 [[package]]
 name = "jaraco-classes"
@@ -5722,4 +5722,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "39c073285d7ab5dccb6249fa6a5aa31285ccaa988aa1eced583f71ca4816566d"
+content-hash = "fee4a31b0633084897223d137c1517cac6297e10a342eaefe990a575bcf2290f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ ecs-logging = "^2.3.0"
 [tool.poetry.group.dev.dependencies]
 pre-commit = ">=3.7,<5.0"
 black = "^26.3.1"
-isort = "^5.13.2"
+isort = "^8.0.1"
 pytest = "^9.0.3"
 pytest-asyncio = "^1.4.0"
 dpytest = "^0.7.0"


### PR DESCRIPTION
Supersedes #168.

Three major versions at once (5 to 8), so the thing worth checking is whether the new version sorts differently from the one the tree was last formatted with. It does not.

- Under 5.13.2, `isort --check-only` over `app/`, `tests/`, and `migrations/` is clean. Under 8.0.1 it is also clean, zero files to change. The bump produces no reformatting.
- Our entire configuration is `profile = "black"`, which is stable across these releases. A verbose run reports no deprecation warnings, so nothing in the config has been renamed or removed out from under us.
- The lock diff is isort alone, with no transitive churn. Full suite still passes, 70 tests.

One thing to be aware of: isort 8 requires Python >= 3.10.0. The project floor is `^3.10` and CI runs 3.10, so this is compatible, but it now sits exactly at the floor with no headroom. If a future isort drops 3.10, the project has to raise its own minimum first.

Note that isort is not enforced anywhere in CI. The lint workflow runs black only, so isort exists purely as a local pre-commit hook and this bump cannot turn CI red. Adding isort to the lint workflow would be a reasonable follow-up, but it is a separate change from the bump.