### PR TITLE
feat(weather): add hourly and daily forecast commands

### DIFF
--- a/app/cogs/weather/README.md
+++ b/app/cogs/weather/README.md
@@ -1,3 +1,35 @@
 # Weather
 
 Get the current weather and forecast for any location.
+
+## Commands
+
+| Command | Description |
+|---|---|
+| `weather [location]` | Current conditions, plus air quality |
+| `forecast [location]` | Multi-day outlook, same as `forecast daily` |
+| `forecast daily [location]` | Up to 7 days, with each day's high and low |
+| `forecast hourly [location]` | The next 12 hours |
+
+All of them are available as slash commands too, and all default to
+Lancaster, PA when no location is given. A location can be a place name or a
+US zip code.
+
+Forecast times are rendered in the timezone of the place being forecast, not
+the bot's, so asking for somewhere in another timezone gives the hours a
+person standing there would read.
+
+## Configuration
+
+Needs both `OPENCAGE_API_KEY` (geocoding) and `OPENWEATHERMAP_API_KEY`. The cog
+logs a warning and disables its commands when either is missing.
+
+The forecast uses OpenWeatherMap's One Call 3.0 API, which is a paid
+subscription with a free daily allowance, billed per request. Current
+conditions use the free 2.5 endpoints. One request returns both the hourly and
+daily data, so a location is fetched once and cached for 10 minutes to serve
+both views.
+
+Note that the older `2.5/forecast/daily` endpoint is not part of the free tier
+and returns 401 without a subscription, which is why the forecast is built on
+One Call rather than that.

--- a/app/cogs/weather/weather.py
+++ b/app/cogs/weather/weather.py
@@ -1,12 +1,152 @@
+import asyncio
 import os
 import random
+from datetime import datetime
 
 import cachetools
 import discord
 import pyowm
+import pytz
 from cogs.lancocog import LancoCog
 from discord.ext import commands
 from opencage.geocoder import OpenCageGeocode, OpenCageGeocodeError
+
+DEFAULT_LOCATION = "Lancaster, PA"
+
+# How much of the One Call payload each view shows. It returns 48 hourly and
+# 8 daily entries; both are trimmed to what fits an embed and stays readable.
+HOURLY_HOURS = 12
+DAILY_DAYS = 7
+
+# One Call is billed per request, so a location's whole forecast is fetched
+# once and both views are served from it.
+FORECAST_TTL = 600
+
+# OWM icon prefix -> embed colour. These are the full set OWM documents, but
+# lookups go through _color_for so an icon we do not know about degrades to a
+# neutral colour instead of raising KeyError mid-command.
+ICON_COLORS = {
+    "01": 0xFFFF00,  # clear
+    "02": 0xFFFF00,  # few clouds
+    "03": 0xFFFF00,  # scattered clouds
+    "04": 0xFFFF00,  # broken clouds
+    "09": 0x0000FF,  # shower rain
+    "10": 0x0000FF,  # rain
+    "11": 0x0000FF,  # thunderstorm
+    "13": 0x00FFFF,  # snow
+    "50": 0x00FFFF,  # mist
+}
+FALLBACK_COLOR = 0x95A5A6
+
+ICON_EMOJI = {
+    "01": "☀️",
+    "02": "🌥️",
+    "03": "☁️",
+    "04": "☁️",
+    "09": "🌧️",
+    "10": "🌦️",
+    "11": "⛈️",
+    "13": "❄️",
+    "50": "🌫️",
+}
+FALLBACK_EMOJI = "🌡️"
+
+
+def _icon_key(icon_name: str) -> str:
+    """The two-digit prefix of an OWM icon name, without its day/night suffix."""
+    return (icon_name or "")[:2]
+
+
+def _color_for(icon_name: str) -> int:
+    return ICON_COLORS.get(_icon_key(icon_name), FALLBACK_COLOR)
+
+
+def _emoji_for(icon_name: str) -> str:
+    return ICON_EMOJI.get(_icon_key(icon_name), FALLBACK_EMOJI)
+
+
+def _pop_suffix(pop: float) -> str:
+    """Precipitation chance, omitted entirely when it is zero.
+
+    OWM gives this as a 0-1 fraction. Printing "0%" on every dry day is noise,
+    so a dry entry gets nothing at all.
+    """
+    if not pop:
+        return ""
+    return f"  💧 {round(pop * 100)}%"
+
+
+def _format_hour(when: datetime) -> str:
+    """Local hour as "8 AM".
+
+    Built by hand rather than with strftime's %-I, which is glibc-only and
+    raises on Windows, where the bot is developed.
+    """
+    return when.strftime("%I %p").lstrip("0")
+
+
+def render_daily_row(
+    when: datetime, icon_name: str, high: int, low: int, status: str, pop: float
+) -> str:
+    """One line of the daily view."""
+    return (
+        f"`{when:%a %m/%d}`  {_emoji_for(icon_name)}  "
+        f"**{high}°** / {low}°  {status}{_pop_suffix(pop)}"
+    )
+
+
+def render_hourly_row(
+    when: datetime, icon_name: str, temp: int, status: str, pop: float
+) -> str:
+    """One line of the hourly view."""
+    return (
+        f"`{_format_hour(when):>5}`  {_emoji_for(icon_name)}  "
+        f"**{temp}°**  {status}{_pop_suffix(pop)}"
+    )
+
+
+def build_forecast_embed(location: str, one_call, hourly: bool):
+    """Render a One Call result as an embed."""
+    # Times come back as UTC timestamps. Rendering them in the bot's own
+    # timezone would label a forecast for somewhere else with the wrong
+    # hours, so each entry is converted to the location's timezone.
+    tz = pytz.timezone(one_call.timezone)
+
+    if hourly:
+        entries = one_call.forecast_hourly[:HOURLY_HOURS]
+        rows = [
+            render_hourly_row(
+                datetime.fromtimestamp(w.reference_time(), tz),
+                w.weather_icon_name,
+                round(w.temperature("fahrenheit")["temp"]),
+                w.status,
+                w.precipitation_probability,
+            )
+            for w in entries
+        ]
+        title = f"Hourly forecast for {location}"
+    else:
+        entries = one_call.forecast_daily[:DAILY_DAYS]
+        rows = [
+            render_daily_row(
+                datetime.fromtimestamp(w.reference_time(), tz),
+                w.weather_icon_name,
+                round(w.temperature("fahrenheit")["max"]),
+                round(w.temperature("fahrenheit")["min"]),
+                w.status,
+                w.precipitation_probability,
+            )
+            for w in entries
+        ]
+        title = f"{len(entries)}-day forecast for {location}"
+
+    embed = discord.Embed(
+        title=title,
+        description="\n".join(rows),
+        color=(_color_for(entries[0].weather_icon_name) if entries else FALLBACK_COLOR),
+    )
+    embed.set_footer(text=f"Times shown in {one_call.timezone}")
+    return embed
 
 
 class Weather(LancoCog, name="Weather", description="Fetches the weather"):
@@ -17,6 +157,7 @@ class Weather(LancoCog, name="Weather", description="Fetches the weather"):
         self.location_cache = {}
         self.weather_statuses = cachetools.TTLCache(maxsize=100, ttl=120)
         self.air_statuses = cachetools.TTLCache(maxsize=100, ttl=120)
+        self.forecasts = cachetools.TTLCache(maxsize=100, ttl=FORECAST_TTL)
 
     async def cog_load(self):
         opencage_key = os.getenv("OPENCAGE_API_KEY")
@@ -90,7 +231,7 @@ class Weather(LancoCog, name="Weather", description="Fetches the weather"):
         return air_status
 
     @commands.hybrid_command()
-    async def weather(self, ctx: commands.Context, location: str = "Lancaster, PA"):
+    async def weather(self, ctx: commands.Context, location: str = DEFAULT_LOCATION):
         """Get the weather for a location"""
         if not self.geocoder or not self.owm:
             await ctx.send("Weather is not configured on this bot.")
@@ -114,18 +255,6 @@ class Weather(LancoCog, name="Weather", description="Fetches the weather"):
             f"http://openweathermap.org/img/wn/{weather.weather_icon_name}@2x.png"
         )
 
-        color_map = {
-            "01": 0xFFFF00,  # clear
-            "02": 0xFFFF00,  # few clouds
-            "03": 0xFFFF00,  # scattered clouds
-            "04": 0xFFFF00,  # broken clouds
-            "09": 0x0000FF,  # shower rain
-            "10": 0x0000FF,  # rain
-            "11": 0x0000FF,  # thunderstorm
-            "13": 0x00FFFF,  # snow
-            "50": 0x00FFFF,  # mist
-        }
-
         desc = weather.status
         if weather.detailed_status.lower() != weather.status.lower():
             desc += f" ({weather.detailed_status})"
@@ -146,7 +275,7 @@ class Weather(LancoCog, name="Weather", description="Fetches the weather"):
         embed = discord.Embed(
             title=f"Weather in {location}",
             description=desc,
-            color=color_map[weather.weather_icon_name[:2]],
+            color=_color_for(weather.weather_icon_name),
         )
         embed.add_field(
             name="",
@@ -183,6 +312,73 @@ class Weather(LancoCog, name="Weather", description="Fetches the weather"):
 
         embed.set_thumbnail(url=icon_url)
         await ctx.send(embed=embed)
+
+    async def get_forecast(self, location):
+        """Get the One Call forecast for a location"""
+        coords = await self.get_coords(location)
+        if not coords:
+            return None
+
+        if coords in self.forecasts:
+            return self.forecasts[coords]
+
+        self.logger.info(f"Fetching forecast for coords: {coords}")
+
+        # pyowm is synchronous. The current-weather path calls it inline and
+        # blocks the event loop for the length of the request; a forecast is
+        # the larger payload of the two, so it goes to a thread.
+        one_call = await asyncio.to_thread(
+            self.owm.weather_manager().one_call, lat=coords[0], lon=coords[1]
+        )
+
+        if one_call:
+            self.forecasts[coords] = one_call
+        return one_call
+
+    async def send_forecast(self, ctx: commands.Context, location: str, hourly: bool):
+        """Shared body of the forecast commands."""
+        if not self.geocoder or not self.owm:
+            await ctx.send("Weather is not configured on this bot.")
+            return
+
+        # Geocoding plus One Call can outrun the 3 second interaction deadline.
+        await ctx.defer()
+
+        try:
+            one_call = await self.get_forecast(location)
+        except (OpenCageGeocodeError, pyowm.commons.exceptions.PyOWMError) as e:
+            # Same split as the weather command: a revoked key or a rate limit
+            # is a service problem, not a bad location.
+            self.logger.error(f"Forecast lookup failed for {location}: {e}")
+            await ctx.send("Forecast lookup is unavailable right now.")
+            return
+
+        if not one_call:
+            await ctx.send("Could not find a forecast for that location")
+            return
+
+        await ctx.send(embed=build_forecast_embed(location, one_call, hourly))
+
+    @commands.hybrid_group(name="forecast", invoke_without_command=True)
+    async def forecast(
+        self, ctx: commands.Context, *, location: str = DEFAULT_LOCATION
+    ):
+        """Get the multi-day forecast for a location"""
+        await self.send_forecast(ctx, location, hourly=False)
+
+    @forecast.command(name="daily")
+    async def forecast_daily(
+        self, ctx: commands.Context, *, location: str = DEFAULT_LOCATION
+    ):
+        """Get the multi-day forecast for a location"""
+        await self.send_forecast(ctx, location, hourly=False)
+
+    @forecast.command(name="hourly")
+    async def forecast_hourly(
+        self, ctx: commands.Context, *, location: str = DEFAULT_LOCATION
+    ):
+        """Get the hour-by-hour forecast for a location"""
+        await self.send_forecast(ctx, location, hourly=True)
 
 
 async def setup(bot):

--- a/tests/test_weather_forecast.py
+++ b/tests/test_weather_forecast.py
@@ -1,0 +1,141 @@
+"""Forecast rendering tests.
+
+The rendering helpers are pure so they can be checked without touching the
+OpenWeatherMap API. The two things worth pinning are that entries are shown in
+the forecast location's timezone rather than the bot's, and that a dry entry
+prints no precipitation chance at all.
+"""
+
+from datetime import datetime
+from types import SimpleNamespace
+
+import pytest
+import pytz
+from cogs.weather.weather import (
+    DAILY_DAYS,
+    FALLBACK_COLOR,
+    FALLBACK_EMOJI,
+    HOURLY_HOURS,
+    _color_for,
+    _emoji_for,
+    _format_hour,
+    _pop_suffix,
+    build_forecast_embed,
+    render_daily_row,
+    render_hourly_row,
+)
+
+UTC = pytz.UTC
+
+
+def test_unknown_icon_degrades_instead_of_raising():
+    # The command used to index the colour map directly, so an icon outside
+    # the documented set would have raised KeyError mid-render.
+    assert _color_for("99z") == FALLBACK_COLOR
+    assert _emoji_for("99z") == FALLBACK_EMOJI
+    assert _color_for(None) == FALLBACK_COLOR
+    assert _emoji_for("") == FALLBACK_EMOJI
+
+
+def test_icon_lookup_ignores_day_night_suffix():
+    assert _color_for("04d") == _color_for("04n")
+    assert _emoji_for("01d") == _emoji_for("01n")
+
+
+@pytest.mark.parametrize(
+    "pop,expected",
+    [(0, ""), (None, ""), (0.5, "50%"), (1, "100%"), (0.666, "67%")],
+)
+def test_pop_suffix(pop, expected):
+    suffix = _pop_suffix(pop)
+    if expected:
+        assert expected in suffix
+    else:
+        assert suffix == ""
+
+
+@pytest.mark.parametrize(
+    "hour,expected",
+    [(0, "12 AM"), (4, "4 AM"), (12, "12 PM"), (13, "1 PM"), (23, "11 PM")],
+)
+def test_format_hour_has_no_leading_zero(hour, expected):
+    # Built by hand because strftime's %-I is glibc-only and raises on Windows.
+    assert _format_hour(datetime(2026, 8, 22, hour)) == expected
+
+
+def test_render_daily_row():
+    row = render_daily_row(datetime(2026, 8, 22), "10d", 74, 63, "Rain", 1)
+    assert "Sat 08/22" in row
+    assert "74" in row and "63" in row
+    assert "Rain" in row
+    assert "100%" in row
+
+
+def test_render_hourly_row_omits_dry_precipitation():
+    wet = render_hourly_row(datetime(2026, 8, 22, 13), "10d", 73, "Rain", 0.91)
+    dry = render_hourly_row(datetime(2026, 8, 22, 13), "01d", 73, "Clear", 0)
+    assert "91%" in wet
+    assert "%" not in dry
+    assert "1 PM" in dry
+
+
+def _weather(ts, icon, status, pop, temps):
+    return SimpleNamespace(
+        reference_time=lambda *a, **k: ts,
+        weather_icon_name=icon,
+        status=status,
+        precipitation_probability=pop,
+        temperature=lambda unit: temps,
+    )
+
+
+def _one_call(timezone="America/New_York", hourly_n=48, daily_n=8):
+    # 2026-08-22 12:00 UTC is 08:00 in New York, which is what the rendered
+    # rows should say.
+    base = int(datetime(2026, 8, 22, 12, tzinfo=UTC).timestamp())
+    return SimpleNamespace(
+        timezone=timezone,
+        forecast_hourly=[
+            _weather(base + i * 3600, "01d", "Clear", 0, {"temp": 70 + i})
+            for i in range(hourly_n)
+        ],
+        forecast_daily=[
+            _weather(base + i * 86400, "10d", "Rain", 1, {"max": 80 + i, "min": 60 + i})
+            for i in range(daily_n)
+        ],
+    )
+
+
+def test_entries_render_in_the_forecast_locations_timezone():
+    # The same instant is a different wall clock in each zone. Rendering in the
+    # bot's own timezone would label a forecast for elsewhere with wrong hours.
+    eastern = build_forecast_embed("x", _one_call("America/New_York"), hourly=True)
+    pacific = build_forecast_embed("x", _one_call("America/Los_Angeles"), hourly=True)
+
+    assert "8 AM" in eastern.description.split("\n")[0]
+    assert "5 AM" in pacific.description.split("\n")[0]
+    assert "America/New_York" in eastern.footer.text
+
+
+def test_views_are_trimmed_to_their_limits():
+    hourly = build_forecast_embed("x", _one_call(), hourly=True)
+    daily = build_forecast_embed("x", _one_call(), hourly=False)
+
+    assert len(hourly.description.split("\n")) == HOURLY_HOURS
+    assert len(daily.description.split("\n")) == DAILY_DAYS
+    assert daily.title.startswith(f"{DAILY_DAYS}-day")
+    assert "Hourly" in hourly.title
+
+
+def test_short_forecast_titles_itself_by_actual_length():
+    # OWM can return fewer entries than we ask for; the title must not claim
+    # more days than the embed actually lists.
+    embed = build_forecast_embed("x", _one_call(daily_n=3), hourly=False)
+    assert embed.title.startswith("3-day")
+    assert len(embed.description.split("\n")) == 3
+
+
+def test_embed_stays_within_discord_description_limit():
+    for hourly in (True, False):
+        embed = build_forecast_embed("x", _one_call(), hourly=hourly)
+        assert len(embed.description) < 4096


### PR DESCRIPTION
Part of #71. Leaves the per-user default location and radar for later.

| Command | Shows |
|---|---|
| `forecast [location]` | same as `forecast daily` |
| `forecast daily [location]` | up to 7 days, high and low per day |
| `forecast hourly [location]` | next 12 hours |

Also `/forecast daily` and `/forecast hourly`. `location` is consume-rest, so `!forecast Lancaster, PA` works unquoted.

**Why One Call:** probed against our key rather than assuming. `2.5/forecast/daily` returns 401, but `3.0/onecall` returns 200, and pyowm already points at `/data/3.0`. One Call gives 48 hourly and 8 daily entries per request, so both views come from one call, cached 10 minutes since it is billed per request. The free `2.5/forecast` is 3-hourly and caps at 5 days.

Worth knowing while reviewing:

- Entries render in the forecast location's timezone, not the bot's. Pinned by a test comparing the same instant in New York and Los Angeles.
- The colour map moved out of the command body and now falls back instead of raising. An icon outside the documented set was previously a `KeyError` mid-render.
- 18 tests, no network needed, suite at 88.

`!forecast Lancaster, PA` works unquoted but `!weather Lancaster, PA` does not, since that command takes a positional `location` and captures only `Lancaster,`. One-token fix, but it changes existing behaviour so I left it out. Fold in here or do separately?